### PR TITLE
Remove OpenShift Python client

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,8 +19,6 @@
 		"dg",
 		"--thirdparty",
 		"click",
-		"--thirdparty",
-		"openshift",
 		"--trailing-comma"
 	],
 	"python.testing.nosetestsEnabled": false,

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,6 @@ setup(
         "asyncssh",
         "click",
         "colorama",
-        "kubernetes < 12.0.0",
-        "openshift",
         "pyyaml",
         "requests",
         "semver",


### PR DESCRIPTION
This pull request contains the following changes:

- Remove [OpenShift Python client](https://github.com/openshift/openshift-restclient-python) until new version using [Kubernetes Python client](https://github.com/kubernetes-client/python) >= 12.0.0 is released.