### PR TITLE
Improve import dependencies

### DIFF
--- a/dg/commands/cluster/install_assembly.py
+++ b/dg/commands/cluster/install_assembly.py
@@ -17,7 +17,6 @@ from typing import Union
 import click
 import semver
 
-import dg.config
 import dg.config.cluster_credentials_manager
 import dg.utils.click
 import dg.utils.download
@@ -33,7 +32,7 @@ from dg.lib.cloud_pak_for_data.cpd_manager_factory import (
 
 @click.command(
     context_settings=dg.utils.click.create_default_map_from_dict(
-        dg.config.data_gate_configuration_manager.get_current_credentials()
+        dg.config.cluster_credentials_manager.cluster_credentials_manager.get_current_credentials()
     )
 )
 @click.option("--server", required=True, help="OpenShift server URL")

--- a/dg/commands/cluster/install_cloud_pak_for_data.py
+++ b/dg/commands/cluster/install_cloud_pak_for_data.py
@@ -34,7 +34,7 @@ from dg.lib.cloud_pak_for_data.cpd_manager_factory import (
 
 @click.command(
     context_settings=dg.utils.click.create_default_map_from_dict(
-        dg.config.data_gate_configuration_manager.get_current_credentials()
+        dg.config.cluster_credentials_manager.cluster_credentials_manager.get_current_credentials()
     )
 )
 @click.option("--server", required=True, help="OpenShift server URL")

--- a/dg/commands/cluster/install_data_gate.py
+++ b/dg/commands/cluster/install_data_gate.py
@@ -17,7 +17,6 @@ from typing import Union
 import click
 import semver
 
-import dg.config
 import dg.config.cluster_credentials_manager
 import dg.utils.click
 import dg.utils.download
@@ -33,7 +32,7 @@ from dg.lib.cloud_pak_for_data.cpd_manager_factory import (
 
 @click.command(
     context_settings=dg.utils.click.create_default_map_from_dict(
-        dg.config.data_gate_configuration_manager.get_current_credentials()
+        dg.config.cluster_credentials_manager.cluster_credentials_manager.get_current_credentials()
     )
 )
 @click.option("--server", required=True, help="OpenShift server URL")

--- a/dg/commands/cluster/install_db2.py
+++ b/dg/commands/cluster/install_db2.py
@@ -17,7 +17,6 @@ from typing import Union
 import click
 import semver
 
-import dg.config
 import dg.config.cluster_credentials_manager
 import dg.lib.cloud_pak_for_data.cpd_manager_factory
 import dg.utils.click
@@ -34,7 +33,7 @@ from dg.lib.cloud_pak_for_data.cpd_manager_factory import (
 
 @click.command(
     context_settings=dg.utils.click.create_default_map_from_dict(
-        dg.config.data_gate_configuration_manager.get_current_credentials()
+        dg.config.cluster_credentials_manager.cluster_credentials_manager.get_current_credentials()
     )
 )
 @click.option("--server", required=True, help="OpenShift server URL")

--- a/dg/commands/cluster/login.py
+++ b/dg/commands/cluster/login.py
@@ -14,7 +14,6 @@
 
 import click
 
-import dg.config
 import dg.config.cluster_credentials_manager
 import dg.lib.fyre.cluster.fyre_cluster_factory  # required to register FYREClusterFactory object
 import dg.lib.ibmcloud.cluster.ibmcloud_cluster_factory  # required to register IBMCloudClusterFactory object
@@ -23,7 +22,7 @@ import dg.utils.click
 
 @click.command(
     context_settings=dg.utils.click.create_default_map_from_dict(
-        dg.config.data_gate_configuration_manager.get_current_credentials()
+        dg.config.cluster_credentials_manager.cluster_credentials_manager.get_current_credentials()
     )
 )
 def login():

--- a/dg/commands/fyre/cluster/copy_ssh_key.py
+++ b/dg/commands/fyre/cluster/copy_ssh_key.py
@@ -16,13 +16,13 @@ import subprocess
 
 import click
 
-import dg.config
+import dg.config.cluster_credentials_manager
 import dg.utils.click
 
 
 @click.command(
     context_settings=dg.utils.click.create_default_map_from_dict(
-        dg.config.data_gate_configuration_manager.get_current_credentials()
+        dg.config.cluster_credentials_manager.cluster_credentials_manager.get_current_credentials()
     )
 )
 @click.option(

--- a/dg/commands/fyre/cluster/get_cluster_access_token.py
+++ b/dg/commands/fyre/cluster/get_cluster_access_token.py
@@ -14,7 +14,7 @@
 
 import click
 
-import dg.config
+import dg.config.cluster_credentials_manager
 import dg.utils.click
 
 from dg.lib.fyre.cluster.fyre_cluster_factory import fyre_cluster_factory
@@ -22,7 +22,7 @@ from dg.lib.fyre.cluster.fyre_cluster_factory import fyre_cluster_factory
 
 @click.command(
     context_settings=dg.utils.click.create_default_map_from_dict(
-        dg.config.data_gate_configuration_manager.get_current_credentials()
+        dg.config.cluster_credentials_manager.cluster_credentials_manager.get_current_credentials()
     )
 )
 @click.option(

--- a/dg/commands/fyre/cluster/init_node_for_data_gate.py
+++ b/dg/commands/fyre/cluster/init_node_for_data_gate.py
@@ -17,13 +17,14 @@ import asyncio
 import click
 
 import dg.config
+import dg.config.cluster_credentials_manager
 import dg.utils.click
 import dg.utils.ssh
 
 
 @click.command(
     context_settings=dg.utils.click.create_default_map_from_dict(
-        dg.config.data_gate_configuration_manager.get_current_credentials()
+        dg.config.cluster_credentials_manager.cluster_credentials_manager.get_current_credentials()
     )
 )
 @click.option(

--- a/dg/commands/fyre/cluster/init_node_for_db2.py
+++ b/dg/commands/fyre/cluster/init_node_for_db2.py
@@ -18,7 +18,7 @@ from typing import Union
 
 import click
 
-import dg.config
+import dg.config.cluster_credentials_manager
 import dg.utils.click
 import dg.utils.openshift
 import dg.utils.ssh
@@ -26,7 +26,7 @@ import dg.utils.ssh
 
 @click.command(
     context_settings=dg.utils.click.create_default_map_from_dict(
-        dg.config.data_gate_configuration_manager.get_current_credentials()
+        dg.config.cluster_credentials_manager.cluster_credentials_manager.get_current_credentials()
     )
 )
 @click.option(

--- a/dg/commands/fyre/cluster/install_nfs_storage_class.py
+++ b/dg/commands/fyre/cluster/install_nfs_storage_class.py
@@ -20,7 +20,6 @@ from typing import Final, Union
 
 import click
 
-import dg.config
 import dg.config.cluster_credentials_manager
 import dg.utils.click
 import dg.utils.download
@@ -43,7 +42,7 @@ def get_private_ip_address_of_infrastructure_node(hostname_result: str):
 
 @click.command(
     context_settings=dg.utils.click.create_default_map_from_dict(
-        dg.config.data_gate_configuration_manager.get_current_credentials()
+        dg.config.cluster_credentials_manager.cluster_credentials_manager.get_current_credentials()
     )
 )
 @click.option(

--- a/dg/commands/fyre/cluster/login.py
+++ b/dg/commands/fyre/cluster/login.py
@@ -16,7 +16,7 @@ from typing import Union
 
 import click
 
-import dg.config
+import dg.config.cluster_credentials_manager
 import dg.utils.click
 
 from dg.lib.fyre.cluster.fyre_cluster_factory import fyre_cluster_factory
@@ -24,7 +24,7 @@ from dg.lib.fyre.cluster.fyre_cluster_factory import fyre_cluster_factory
 
 @click.command(
     context_settings=dg.utils.click.create_default_map_from_dict(
-        dg.config.data_gate_configuration_manager.get_current_credentials()
+        dg.config.cluster_credentials_manager.cluster_credentials_manager.get_current_credentials()
     )
 )
 @click.option("--cluster-name", required=True, help="cluster name")

--- a/dg/config/__init__.py
+++ b/dg/config/__init__.py
@@ -18,43 +18,9 @@ import sys
 
 from typing import Any, Union
 
-import dg.config.cluster_credentials_manager
-
-ContextData = dict[str, Any]
-
 
 class DataGateConfigurationManager:
     """Manages the Data Gate CLI configuration"""
-
-    def get_current_credentials(self) -> ContextData:
-        """Returns user and current cluster credentials
-
-        Returns
-        -------
-        ContextData
-            user and current cluster credentials
-        """
-
-        dg_credentials_file_path = self.get_dg_credentials_file_path()
-        result: ContextData
-
-        if dg_credentials_file_path.exists() and (
-            dg_credentials_file_path.stat().st_size != 0
-        ):
-            with open(dg_credentials_file_path) as json_file:
-                result = json.load(json_file)
-        else:
-            result = {}
-
-        current_cluster = (
-            dg.config.cluster_credentials_manager.cluster_credentials_manager.get_current_cluster()
-        )
-
-        if current_cluster is not None:
-            result.update(current_cluster.get_cluster_data())
-            result["server"] = current_cluster.get_server()
-
-        return result
 
     def get_deps_directory_path(self) -> pathlib.Path:
         """Returns the path of the directory containing required non-Python
@@ -68,27 +34,41 @@ class DataGateConfigurationManager:
 
         return self.get_root_package_path() / "deps"
 
+    def get_dg_directory_path(self) -> pathlib.Path:
+        """Return the path of the Data Gate CLI directory
+
+        Returns
+        -------
+        pathlib.Path
+            path of the Data Gate CLI directory
+        """
+
+        return self.get_home_directory_path() / ".dg"
+
     def get_dg_bin_directory_path(self) -> pathlib.Path:
         """Returns the path of the binaries directory
 
         Returns
         -------
-        str
+        pathlib.Path
             path of the binaries directory
         """
 
-        return pathlib.Path.home() / ".dg" / "bin"
+        return self.get_dg_directory_path() / "bin"
 
     def get_dg_credentials_file_path(self) -> pathlib.Path:
         """Returns the path of the credentials file
 
         Returns
         -------
-        str
+        pathlib.Path
             path of the credentials file
         """
 
-        return pathlib.Path.home() / ".dg" / "credentials.json"
+        return self.get_dg_directory_path() / "credentials.json"
+
+    def get_home_directory_path(self) -> pathlib.Path:
+        return pathlib.Path.home()
 
     def get_ibmcloud_cli_path(self) -> pathlib.Path:
         """Returns the path to the IBM Cloud CLI

--- a/dg/config/binaries_manager.py
+++ b/dg/config/binaries_manager.py
@@ -17,6 +17,8 @@ import pathlib
 
 from typing import Union
 
+from dg.config import data_gate_configuration_manager
+
 BinariesFileContents = dict[str, str]
 
 
@@ -24,7 +26,7 @@ class BinariesManager:
     """Manages downloaded binaries"""
 
     def __init__(self):
-        self._binaries_file_contents = self.get_binaries_file_contents_with_default()
+        self._binaries_file_contents: Union[dict[str, str], None] = None
 
     def get_binaries_file_contents(self) -> Union[BinariesFileContents, None]:
         """Returns the contents of the binaries file
@@ -71,7 +73,7 @@ class BinariesManager:
             path of the binaries file
         """
 
-        return pathlib.Path.home() / ".dg" / "binaries.json"
+        return data_gate_configuration_manager.get_dg_directory_path() / "binaries.json"
 
     def get_binary_version(self, binary_alias: str) -> Union[str, None]:
         binaries = self._get_binary_versions()
@@ -93,16 +95,21 @@ class BinariesManager:
             versions of downloaded binaries
         """
 
+        if self._binaries_file_contents is None:
+            self._binaries_file_contents = (
+                self.get_binaries_file_contents_with_default()
+            )
+
         return self._binaries_file_contents
 
     def _save_binaries_file(self):
         """Stores versions of downloaded binaries in a configuration file"""
 
-        (pathlib.Path.home() / ".dg").mkdir(exist_ok=True)
+        data_gate_configuration_manager.get_dg_directory_path().mkdir(exist_ok=True)
 
         with open(self.get_dg_binaries_file_path(), "w") as binaries_file:
             json.dump(
-                self._binaries_file_contents,
+                self._get_binary_versions(),
                 binaries_file,
                 indent="\t",
                 sort_keys=True,

--- a/dg/config/cluster_credentials_manager.py
+++ b/dg/config/cluster_credentials_manager.py
@@ -210,6 +210,9 @@ class ClusterCredentialsManager:
     def get_current_credentials(self) -> ContextData:
         """Returns user and current cluster credentials
 
+        User credentials are obtained from ~/.dg/credentials.json. Cluster
+        credentials are obtained from ~/.dg/clusters.json.
+
         Returns
         -------
         ContextData

--- a/dg/config/cluster_credentials_manager.py
+++ b/dg/config/cluster_credentials_manager.py
@@ -15,13 +15,16 @@
 import json
 import pathlib
 
-from typing import TypedDict, Union
+from typing import Any, TypedDict, Union
+from dg.config import data_gate_configuration_manager
 
 from tabulate import tabulate
 
 import dg.lib.cluster
 
 from dg.lib.cluster.cluster import AbstractCluster, ClusterData
+
+ContextData = dict[str, Any]
 
 
 class ClustersFileContents(TypedDict):
@@ -204,6 +207,36 @@ class ClusterCredentialsManager:
 
         return cluster
 
+    def get_current_credentials(self) -> ContextData:
+        """Returns user and current cluster credentials
+
+        Returns
+        -------
+        ContextData
+            user and current cluster credentials
+        """
+
+        dg_credentials_file_path = (
+            data_gate_configuration_manager.get_dg_credentials_file_path()
+        )
+        result: ContextData
+
+        if dg_credentials_file_path.exists() and (
+            dg_credentials_file_path.stat().st_size != 0
+        ):
+            with open(dg_credentials_file_path) as json_file:
+                result = json.load(json_file)
+        else:
+            result = {}
+
+        current_cluster = self.get_current_cluster()
+
+        if current_cluster is not None:
+            result.update(current_cluster.get_cluster_data())
+            result["server"] = current_cluster.get_server()
+
+        return result
+
     def get_dg_clusters_file_path(self) -> pathlib.Path:
         """Returns the path of the clusters file
 
@@ -213,7 +246,7 @@ class ClusterCredentialsManager:
             path of the clusters file
         """
 
-        return pathlib.Path.home() / ".dg" / "clusters.json"
+        return data_gate_configuration_manager.get_dg_directory_path() / "clusters.json"
 
     def reload(self):
         """Reloads the clusters file"""
@@ -331,7 +364,7 @@ class ClusterCredentialsManager:
     def _save_clusters_file(self):
         """Stores registered OpenShift clusters in a configuration file"""
 
-        (pathlib.Path.home() / ".dg").mkdir(exist_ok=True)
+        data_gate_configuration_manager.get_dg_directory_path().mkdir(exist_ok=True)
 
         with open(self.get_dg_clusters_file_path(), "w") as clusters_file:
             json.dump(


### PR DESCRIPTION
This pull request contains the following changes:

- Improve import dependencies between `dg.config` and `dg.config.cluster_credentials_manager` packages to avoid circular dependencies.
- Use `dg.config.data_gate_configuration_manager` to obtain configuration directories.
- Lazily load `~/.dg/binaries.json` to support mocking.