### PR TITLE
Specify --artifactory-user-name and --artifactory-api-key as optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ def {Click group name}():
     pass
 ```
 
-### Avoiding circular imports
+#### Avoiding circular imports
 
 To avoid circular imports, a module contained in one of the Data Gate CLI packages shown in the table below is only allowed to import other modules of the following categories:
 

--- a/dg/commands/cluster/install_assembly.py
+++ b/dg/commands/cluster/install_assembly.py
@@ -17,6 +17,8 @@ from typing import Union
 import click
 import semver
 
+from click_option_group import optgroup
+
 import dg.config.cluster_credentials_manager
 import dg.lib.click
 import dg.lib.openshift
@@ -35,44 +37,47 @@ from dg.lib.cloud_pak_for_data.cpd_manager_factory import (
         dg.config.cluster_credentials_manager.cluster_credentials_manager.get_current_credentials()
     )
 )
-@click.option("--server", required=True, help="OpenShift server URL")
-@click.option("--username", help="OpenShift username")
-@click.option("--password", help="OpenShift password")
-@click.option("--token", help="OpenShift OAuth access token")
-@click.option("--artifactory-user-name", help="Artifactory user name")
-@click.option("--artifactory-api-key", help="Artifactory API key")
-@click.option(
+@optgroup.group("Release build options")
+@optgroup.option(
     "--ibm-cloud-pak-for-data-entitlement-key",
     help="IBM Cloud Pak for Data entitlement key",
 )
-@click.option(
+@optgroup.group("Development build options")
+@optgroup.option("--artifactory-user-name", help="Artifactory user name")
+@optgroup.option("--artifactory-api-key", help="Artifactory API key")
+@optgroup.option("--use-dev", is_flag=True, help="Use development build")
+@optgroup.group("Shared options")
+@optgroup.option("--server", required=True, help="OpenShift server URL")
+@optgroup.option("--username", help="OpenShift username")
+@optgroup.option("--password", help="OpenShift password")
+@optgroup.option("--token", help="OpenShift OAuth access token")
+@optgroup.option(
     "--assembly-name", required=True, help="Name of the assembly to be installed"
 )
-@click.option(
+@optgroup.option(
     "--storage-class",
     required=True,
     help="Storage class used for installation",
 )
-@click.option(
+@optgroup.option(
     "--version",
     default=AbstractCloudPakForDataManager.get_default_cloud_pak_for_data_version(),
     help="Cloud Pak for Data version",
 )
-@click.option("--use-dev", is_flag=True, help="Use development build")
 @click.pass_context
 def install_assembly(
     ctx: click.Context,
+    ibm_cloud_pak_for_data_entitlement_key: Union[str, None],
+    artifactory_user_name: str,
+    artifactory_api_key: str,
+    use_dev: bool,
     server: str,
     username: Union[str, None],
     password: Union[str, None],
     token: Union[str, None],
-    artifactory_user_name: str,
-    artifactory_api_key: str,
-    ibm_cloud_pak_for_data_entitlement_key: Union[str, None],
     assembly_name: str,
     storage_class: str,
     version: str,
-    use_dev: bool,
 ):
     """Install an IBM Cloud Pak for Data assembly"""
 

--- a/dg/commands/cluster/install_assembly.py
+++ b/dg/commands/cluster/install_assembly.py
@@ -26,6 +26,7 @@ import dg.utils.download
 
 from dg.lib.cloud_pak_for_data.cpd_manager import (
     AbstractCloudPakForDataManager,
+    CloudPakForDataAssemblyBuildType,
 )
 from dg.lib.cloud_pak_for_data.cpd_manager_factory import (
     CloudPakForDataManagerFactory,
@@ -37,15 +38,6 @@ from dg.lib.cloud_pak_for_data.cpd_manager_factory import (
         dg.config.cluster_credentials_manager.cluster_credentials_manager.get_current_credentials()
     )
 )
-@optgroup.group("Release build options")
-@optgroup.option(
-    "--ibm-cloud-pak-for-data-entitlement-key",
-    help="IBM Cloud Pak for Data entitlement key",
-)
-@optgroup.group("Development build options")
-@optgroup.option("--artifactory-user-name", help="Artifactory user name")
-@optgroup.option("--artifactory-api-key", help="Artifactory API key")
-@optgroup.option("--use-dev", is_flag=True, help="Use development build")
 @optgroup.group("Shared options")
 @optgroup.option("--server", required=True, help="OpenShift server URL")
 @optgroup.option("--username", help="OpenShift username")
@@ -53,6 +45,15 @@ from dg.lib.cloud_pak_for_data.cpd_manager_factory import (
 @optgroup.option("--token", help="OpenShift OAuth access token")
 @optgroup.option(
     "--assembly-name", required=True, help="Name of the assembly to be installed"
+)
+@optgroup.option(
+    "--build-type",
+    default=f"{CloudPakForDataAssemblyBuildType.RELEASE.name}",
+    help=f"Build type (default: {CloudPakForDataAssemblyBuildType.RELEASE.name.lower()})",
+    type=click.Choice(
+        list(map(lambda x: x.name.lower(), CloudPakForDataAssemblyBuildType)),
+        case_sensitive=False,
+    ),
 )
 @optgroup.option(
     "--storage-class",
@@ -64,30 +65,45 @@ from dg.lib.cloud_pak_for_data.cpd_manager_factory import (
     default=AbstractCloudPakForDataManager.get_default_cloud_pak_for_data_version(),
     help="Cloud Pak for Data version",
 )
+@optgroup.group("Release build options")
+@optgroup.option(
+    "--ibm-cloud-pak-for-data-entitlement-key",
+    help="IBM Cloud Pak for Data entitlement key",
+)
+@optgroup.group("Development build options")
+@optgroup.option("--artifactory-user-name", help="Artifactory user name")
+@optgroup.option("--artifactory-api-key", help="Artifactory API key")
 @click.pass_context
 def install_assembly(
     ctx: click.Context,
     ibm_cloud_pak_for_data_entitlement_key: Union[str, None],
     artifactory_user_name: str,
     artifactory_api_key: str,
-    use_dev: bool,
     server: str,
     username: Union[str, None],
     password: Union[str, None],
     token: Union[str, None],
     assembly_name: str,
+    build_type: str,
     storage_class: str,
     version: str,
 ):
     """Install an IBM Cloud Pak for Data assembly"""
 
-    dg.lib.click.check_cloud_pak_for_data_options(ctx, use_dev, locals().copy())
+    cloud_pak_for_data_assembly_build_type = CloudPakForDataAssemblyBuildType[
+        build_type.upper()
+    ]
+
+    dg.lib.click.check_cloud_pak_for_data_options(
+        ctx, cloud_pak_for_data_assembly_build_type, locals().copy()
+    )
+
     dg.lib.click.log_in_to_openshift_cluster(ctx, locals().copy())
 
     cloud_pak_for_data_manager = (
         CloudPakForDataManagerFactory.get_cloud_pak_for_data_manager(
             semver.VersionInfo.parse(version)
-        )(use_dev)
+        )(cloud_pak_for_data_assembly_build_type)
     )
 
     cloud_pak_for_data_manager.install_assembly_with_prerequisites(

--- a/dg/commands/cluster/install_assembly.py
+++ b/dg/commands/cluster/install_assembly.py
@@ -39,8 +39,8 @@ from dg.lib.cloud_pak_for_data.cpd_manager_factory import (
 @click.option("--username", help="OpenShift username")
 @click.option("--password", help="OpenShift password")
 @click.option("--token", help="OpenShift OAuth access token")
-@click.option("--artifactory-user-name", required=True, help="Artifactory user name")
-@click.option("--artifactory-api-key", required=True, help="Artifactory API key")
+@click.option("--artifactory-user-name", help="Artifactory user name")
+@click.option("--artifactory-api-key", help="Artifactory API key")
 @click.option(
     "--ibm-cloud-pak-for-data-entitlement-key",
     help="IBM Cloud Pak for Data entitlement key",
@@ -76,12 +76,7 @@ def install_assembly(
 ):
     """Install an IBM Cloud Pak for Data assembly"""
 
-    if not use_dev and ibm_cloud_pak_for_data_entitlement_key is None:
-        raise click.UsageError(
-            "Missing option '--ibm-cloud-pak-for-data-entitlement-key'.",
-            ctx,
-        )
-
+    dg.lib.click.check_cloud_pak_for_data_options(ctx, use_dev, locals().copy())
     dg.lib.click.log_in_to_openshift_cluster(ctx, locals().copy())
 
     cloud_pak_for_data_manager = (

--- a/dg/commands/cluster/install_cloud_pak_for_data.py
+++ b/dg/commands/cluster/install_cloud_pak_for_data.py
@@ -17,6 +17,8 @@ from typing import Union
 import click
 import semver
 
+from click_option_group import optgroup
+
 import dg.config
 import dg.config.cluster_credentials_manager
 import dg.lib.click
@@ -37,40 +39,43 @@ from dg.lib.cloud_pak_for_data.cpd_manager_factory import (
         dg.config.cluster_credentials_manager.cluster_credentials_manager.get_current_credentials()
     )
 )
-@click.option("--server", required=True, help="OpenShift server URL")
-@click.option("--username", help="OpenShift username")
-@click.option("--password", help="OpenShift password")
-@click.option("--token", help="OpenShift OAuth access token")
-@click.option("--artifactory-user-name", help="Artifactory user name")
-@click.option("--artifactory-api-key", help="Artifactory API key")
-@click.option(
+@optgroup.group("Release build options")
+@optgroup.option(
     "--ibm-cloud-pak-for-data-entitlement-key",
     help="IBM Cloud Pak for Data entitlement key",
 )
-@click.option(
+@optgroup.group("Development build options")
+@optgroup.option("--artifactory-user-name", help="Artifactory user name")
+@optgroup.option("--artifactory-api-key", help="Artifactory API key")
+@optgroup.option("--use-dev", is_flag=True, help="Use development build")
+@optgroup.group("Shared options")
+@optgroup.option("--server", required=True, help="OpenShift server URL")
+@optgroup.option("--username", help="OpenShift username")
+@optgroup.option("--password", help="OpenShift password")
+@optgroup.option("--token", help="OpenShift OAuth access token")
+@optgroup.option(
     "--storage-class",
     required=True,
     help="Storage class used for installation",
 )
-@click.option(
+@optgroup.option(
     "--version",
     default=AbstractCloudPakForDataManager.get_default_cloud_pak_for_data_version(),
     help="Cloud Pak for Data version",
 )
-@click.option("--use-dev", is_flag=True, help="Use development build")
 @click.pass_context
 def install_cloud_pak_for_data(
     ctx: click.Context,
+    ibm_cloud_pak_for_data_entitlement_key: Union[str, None],
+    artifactory_user_name: str,
+    artifactory_api_key: str,
+    use_dev: bool,
     server: str,
     username: Union[str, None],
     password: Union[str, None],
     token: Union[str, None],
-    artifactory_user_name: str,
-    artifactory_api_key: str,
-    ibm_cloud_pak_for_data_entitlement_key: Union[str, None],
     storage_class: str,
     version: str,
-    use_dev: bool,
 ):
     """Install IBM Cloud Pak for Data"""
 

--- a/dg/commands/cluster/install_cloud_pak_for_data.py
+++ b/dg/commands/cluster/install_cloud_pak_for_data.py
@@ -41,8 +41,8 @@ from dg.lib.cloud_pak_for_data.cpd_manager_factory import (
 @click.option("--username", help="OpenShift username")
 @click.option("--password", help="OpenShift password")
 @click.option("--token", help="OpenShift OAuth access token")
-@click.option("--artifactory-user-name", required=True, help="Artifactory user name")
-@click.option("--artifactory-api-key", required=True, help="Artifactory API key")
+@click.option("--artifactory-user-name", help="Artifactory user name")
+@click.option("--artifactory-api-key", help="Artifactory API key")
 @click.option(
     "--ibm-cloud-pak-for-data-entitlement-key",
     help="IBM Cloud Pak for Data entitlement key",
@@ -74,12 +74,7 @@ def install_cloud_pak_for_data(
 ):
     """Install IBM Cloud Pak for Data"""
 
-    if not use_dev and ibm_cloud_pak_for_data_entitlement_key is None:
-        raise click.UsageError(
-            "Missing option '--ibm-cloud-pak-for-data-entitlement-key'.",
-            ctx,
-        )
-
+    dg.lib.click.check_cloud_pak_for_data_options(ctx, use_dev, locals().copy())
     dg.lib.click.log_in_to_openshift_cluster(ctx, locals().copy())
 
     override_yaml_file_path = (

--- a/dg/commands/cluster/install_data_gate.py
+++ b/dg/commands/cluster/install_data_gate.py
@@ -17,6 +17,8 @@ from typing import Union
 import click
 import semver
 
+from click_option_group import optgroup
+
 import dg.config.cluster_credentials_manager
 import dg.lib.click
 import dg.lib.openshift
@@ -35,40 +37,43 @@ from dg.lib.cloud_pak_for_data.cpd_manager_factory import (
         dg.config.cluster_credentials_manager.cluster_credentials_manager.get_current_credentials()
     )
 )
-@click.option("--server", required=True, help="OpenShift server URL")
-@click.option("--username", help="OpenShift username")
-@click.option("--password", help="OpenShift password")
-@click.option("--token", help="OpenShift OAuth access token")
-@click.option("--artifactory-user-name", help="Artifactory user name")
-@click.option("--artifactory-api-key", help="Artifactory API key")
-@click.option(
+@optgroup.group("Release build options")
+@optgroup.option(
     "--ibm-cloud-pak-for-data-entitlement-key",
     help="IBM Cloud Pak for Data entitlement key",
 )
-@click.option(
+@optgroup.group("Development build options")
+@optgroup.option("--artifactory-user-name", help="Artifactory user name")
+@optgroup.option("--artifactory-api-key", help="Artifactory API key")
+@optgroup.option("--use-dev", is_flag=True, help="Use development build")
+@optgroup.group("Shared options")
+@optgroup.option("--server", required=True, help="OpenShift server URL")
+@optgroup.option("--username", help="OpenShift username")
+@optgroup.option("--password", help="OpenShift password")
+@optgroup.option("--token", help="OpenShift OAuth access token")
+@optgroup.option(
     "--storage-class",
     required=True,
     help="Storage class used for installation",
 )
-@click.option(
+@optgroup.option(
     "--version",
     default=AbstractCloudPakForDataManager.get_default_cloud_pak_for_data_version(),
     help="Cloud Pak for Data version",
 )
-@click.option("--use-dev", is_flag=True, help="Use development build")
 @click.pass_context
 def install_data_gate(
     ctx: click.Context,
+    ibm_cloud_pak_for_data_entitlement_key: Union[str, None],
+    artifactory_user_name: str,
+    artifactory_api_key: str,
+    use_dev: bool,
     server: str,
     username: Union[str, None],
     password: Union[str, None],
     token: Union[str, None],
-    artifactory_user_name: str,
-    artifactory_api_key: str,
-    ibm_cloud_pak_for_data_entitlement_key: Union[str, None],
     storage_class: str,
     version: str,
-    use_dev: bool,
 ):
     """Install IBM Db2 for z/OS Data Gate"""
 

--- a/dg/commands/cluster/install_data_gate.py
+++ b/dg/commands/cluster/install_data_gate.py
@@ -39,8 +39,8 @@ from dg.lib.cloud_pak_for_data.cpd_manager_factory import (
 @click.option("--username", help="OpenShift username")
 @click.option("--password", help="OpenShift password")
 @click.option("--token", help="OpenShift OAuth access token")
-@click.option("--artifactory-user-name", required=True, help="Artifactory user name")
-@click.option("--artifactory-api-key", required=True, help="Artifactory API key")
+@click.option("--artifactory-user-name", help="Artifactory user name")
+@click.option("--artifactory-api-key", help="Artifactory API key")
 @click.option(
     "--ibm-cloud-pak-for-data-entitlement-key",
     help="IBM Cloud Pak for Data entitlement key",
@@ -72,12 +72,7 @@ def install_data_gate(
 ):
     """Install IBM Db2 for z/OS Data Gate"""
 
-    if not use_dev and ibm_cloud_pak_for_data_entitlement_key is None:
-        raise click.UsageError(
-            "Missing option '--ibm-cloud-pak-for-data-entitlement-key'.",
-            ctx,
-        )
-
+    dg.lib.click.check_cloud_pak_for_data_options(ctx, use_dev, locals().copy())
     dg.lib.click.log_in_to_openshift_cluster(ctx, locals().copy())
 
     cloud_pak_for_data_manager = (

--- a/dg/commands/cluster/install_data_gate.py
+++ b/dg/commands/cluster/install_data_gate.py
@@ -26,6 +26,7 @@ import dg.utils.download
 
 from dg.lib.cloud_pak_for_data.cpd_manager import (
     AbstractCloudPakForDataManager,
+    CloudPakForDataAssemblyBuildType,
 )
 from dg.lib.cloud_pak_for_data.cpd_manager_factory import (
     CloudPakForDataManagerFactory,
@@ -37,20 +38,20 @@ from dg.lib.cloud_pak_for_data.cpd_manager_factory import (
         dg.config.cluster_credentials_manager.cluster_credentials_manager.get_current_credentials()
     )
 )
-@optgroup.group("Release build options")
-@optgroup.option(
-    "--ibm-cloud-pak-for-data-entitlement-key",
-    help="IBM Cloud Pak for Data entitlement key",
-)
-@optgroup.group("Development build options")
-@optgroup.option("--artifactory-user-name", help="Artifactory user name")
-@optgroup.option("--artifactory-api-key", help="Artifactory API key")
-@optgroup.option("--use-dev", is_flag=True, help="Use development build")
 @optgroup.group("Shared options")
 @optgroup.option("--server", required=True, help="OpenShift server URL")
 @optgroup.option("--username", help="OpenShift username")
 @optgroup.option("--password", help="OpenShift password")
 @optgroup.option("--token", help="OpenShift OAuth access token")
+@optgroup.option(
+    "--build-type",
+    default=f"{CloudPakForDataAssemblyBuildType.RELEASE.name}",
+    help=f"Build type (default: {CloudPakForDataAssemblyBuildType.RELEASE.name.lower()})",
+    type=click.Choice(
+        list(map(lambda x: x.name.lower(), CloudPakForDataAssemblyBuildType)),
+        case_sensitive=False,
+    ),
+)
 @optgroup.option(
     "--storage-class",
     required=True,
@@ -61,29 +62,44 @@ from dg.lib.cloud_pak_for_data.cpd_manager_factory import (
     default=AbstractCloudPakForDataManager.get_default_cloud_pak_for_data_version(),
     help="Cloud Pak for Data version",
 )
+@optgroup.group("Release build options")
+@optgroup.option(
+    "--ibm-cloud-pak-for-data-entitlement-key",
+    help="IBM Cloud Pak for Data entitlement key",
+)
+@optgroup.group("Development build options")
+@optgroup.option("--artifactory-user-name", help="Artifactory user name")
+@optgroup.option("--artifactory-api-key", help="Artifactory API key")
 @click.pass_context
 def install_data_gate(
     ctx: click.Context,
     ibm_cloud_pak_for_data_entitlement_key: Union[str, None],
     artifactory_user_name: str,
     artifactory_api_key: str,
-    use_dev: bool,
     server: str,
     username: Union[str, None],
     password: Union[str, None],
     token: Union[str, None],
+    build_type: str,
     storage_class: str,
     version: str,
 ):
     """Install IBM Db2 for z/OS Data Gate"""
 
-    dg.lib.click.check_cloud_pak_for_data_options(ctx, use_dev, locals().copy())
+    cloud_pak_for_data_assembly_build_type = CloudPakForDataAssemblyBuildType[
+        build_type.upper()
+    ]
+
+    dg.lib.click.check_cloud_pak_for_data_options(
+        ctx, cloud_pak_for_data_assembly_build_type, locals().copy()
+    )
+
     dg.lib.click.log_in_to_openshift_cluster(ctx, locals().copy())
 
     cloud_pak_for_data_manager = (
         CloudPakForDataManagerFactory.get_cloud_pak_for_data_manager(
             semver.VersionInfo.parse(version)
-        )(use_dev)
+        )(cloud_pak_for_data_assembly_build_type)
     )
 
     cloud_pak_for_data_manager.install_assembly_with_prerequisites(

--- a/dg/commands/cluster/install_db2.py
+++ b/dg/commands/cluster/install_db2.py
@@ -17,6 +17,8 @@ from typing import Union
 import click
 import semver
 
+from click_option_group import optgroup
+
 import dg.config.cluster_credentials_manager
 import dg.lib.click
 import dg.lib.cloud_pak_for_data.cpd_manager_factory
@@ -36,52 +38,50 @@ from dg.lib.cloud_pak_for_data.cpd_manager_factory import (
         dg.config.cluster_credentials_manager.cluster_credentials_manager.get_current_credentials()
     )
 )
-@click.option("--server", required=True, help="OpenShift server URL")
-@click.option("--username", help="OpenShift username")
-@click.option("--password", help="OpenShift password")
-@click.option("--token", help="OpenShift OAuth access token")
-@click.option("--artifactory-user-name", help="Artifactory user name")
-@click.option("--artifactory-api-key", help="Artifactory API key")
-@click.option(
+@optgroup.group("Release build options")
+@optgroup.option(
     "--ibm-cloud-pak-for-data-entitlement-key",
     help="IBM Cloud Pak for Data entitlement key",
 )
-@click.option(
+@optgroup.group("Development build options")
+@optgroup.option("--artifactory-user-name", help="Artifactory user name")
+@optgroup.option("--artifactory-api-key", help="Artifactory API key")
+@optgroup.option("--use-dev", is_flag=True, help="Use development build")
+@optgroup.group("Shared options")
+@optgroup.option("--server", required=True, help="OpenShift server URL")
+@optgroup.option("--username", help="OpenShift username")
+@optgroup.option("--password", help="OpenShift password")
+@optgroup.option("--token", help="OpenShift OAuth access token")
+@optgroup.option(
     "--db2-edition",
     required=True,
     type=click.Choice(["db2oltp", "db2wh"]),
     help="Db2 edition",
 )
-@click.option(
+@optgroup.option(
     "--storage-class",
     required=True,
     help="Storage class used for installation",
 )
-@click.option(
-    "--storage-class",
-    required=True,
-    help="Storage class used for installation",
-)
-@click.option(
+@optgroup.option(
     "--version",
     default=AbstractCloudPakForDataManager.get_default_cloud_pak_for_data_version(),
     help="Cloud Pak for Data version",
 )
-@click.option("--use-dev", is_flag=True, help="Use development build")
 @click.pass_context
 def install_db2(
     ctx: click.Context,
+    ibm_cloud_pak_for_data_entitlement_key: Union[str, None],
+    artifactory_user_name: str,
+    artifactory_api_key: str,
+    use_dev: bool,
     server: str,
     username: Union[str, None],
     password: Union[str, None],
     token: Union[str, None],
-    artifactory_user_name: str,
-    artifactory_api_key: str,
-    ibm_cloud_pak_for_data_entitlement_key: Union[str, None],
     db2_edition: str,
     storage_class: str,
     version: str,
-    use_dev: bool,
 ):
     """Install IBM Db2 or IBM Db2 Warehouse"""
 

--- a/dg/commands/cluster/install_db2.py
+++ b/dg/commands/cluster/install_db2.py
@@ -27,6 +27,7 @@ import dg.utils.download
 
 from dg.lib.cloud_pak_for_data.cpd_manager import (
     AbstractCloudPakForDataManager,
+    CloudPakForDataAssemblyBuildType,
 )
 from dg.lib.cloud_pak_for_data.cpd_manager_factory import (
     CloudPakForDataManagerFactory,
@@ -38,20 +39,20 @@ from dg.lib.cloud_pak_for_data.cpd_manager_factory import (
         dg.config.cluster_credentials_manager.cluster_credentials_manager.get_current_credentials()
     )
 )
-@optgroup.group("Release build options")
-@optgroup.option(
-    "--ibm-cloud-pak-for-data-entitlement-key",
-    help="IBM Cloud Pak for Data entitlement key",
-)
-@optgroup.group("Development build options")
-@optgroup.option("--artifactory-user-name", help="Artifactory user name")
-@optgroup.option("--artifactory-api-key", help="Artifactory API key")
-@optgroup.option("--use-dev", is_flag=True, help="Use development build")
 @optgroup.group("Shared options")
 @optgroup.option("--server", required=True, help="OpenShift server URL")
 @optgroup.option("--username", help="OpenShift username")
 @optgroup.option("--password", help="OpenShift password")
 @optgroup.option("--token", help="OpenShift OAuth access token")
+@optgroup.option(
+    "--build-type",
+    default=f"{CloudPakForDataAssemblyBuildType.RELEASE.name}",
+    help=f"Build type (default: {CloudPakForDataAssemblyBuildType.RELEASE.name.lower()})",
+    type=click.Choice(
+        list(map(lambda x: x.name.lower(), CloudPakForDataAssemblyBuildType)),
+        case_sensitive=False,
+    ),
+)
 @optgroup.option(
     "--db2-edition",
     required=True,
@@ -68,30 +69,45 @@ from dg.lib.cloud_pak_for_data.cpd_manager_factory import (
     default=AbstractCloudPakForDataManager.get_default_cloud_pak_for_data_version(),
     help="Cloud Pak for Data version",
 )
+@optgroup.group("Release build options")
+@optgroup.option(
+    "--ibm-cloud-pak-for-data-entitlement-key",
+    help="IBM Cloud Pak for Data entitlement key",
+)
+@optgroup.group("Development build options")
+@optgroup.option("--artifactory-user-name", help="Artifactory user name")
+@optgroup.option("--artifactory-api-key", help="Artifactory API key")
 @click.pass_context
 def install_db2(
     ctx: click.Context,
     ibm_cloud_pak_for_data_entitlement_key: Union[str, None],
     artifactory_user_name: str,
     artifactory_api_key: str,
-    use_dev: bool,
     server: str,
     username: Union[str, None],
     password: Union[str, None],
     token: Union[str, None],
+    build_type: str,
     db2_edition: str,
     storage_class: str,
     version: str,
 ):
     """Install IBM Db2 or IBM Db2 Warehouse"""
 
-    dg.lib.click.check_cloud_pak_for_data_options(ctx, use_dev, locals().copy())
+    cloud_pak_for_data_assembly_build_type = CloudPakForDataAssemblyBuildType[
+        build_type.upper()
+    ]
+
+    dg.lib.click.check_cloud_pak_for_data_options(
+        ctx, cloud_pak_for_data_assembly_build_type, locals().copy()
+    )
+
     dg.lib.click.log_in_to_openshift_cluster(ctx, locals().copy())
 
     cloud_pak_for_data_manager = (
         CloudPakForDataManagerFactory.get_cloud_pak_for_data_manager(
             semver.VersionInfo.parse(version)
-        )(use_dev)
+        )(cloud_pak_for_data_assembly_build_type)
     )
 
     cloud_pak_for_data_manager.install_assembly_with_prerequisites(

--- a/dg/commands/cluster/install_db2.py
+++ b/dg/commands/cluster/install_db2.py
@@ -40,8 +40,8 @@ from dg.lib.cloud_pak_for_data.cpd_manager_factory import (
 @click.option("--username", help="OpenShift username")
 @click.option("--password", help="OpenShift password")
 @click.option("--token", help="OpenShift OAuth access token")
-@click.option("--artifactory-user-name", required=True, help="Artifactory user name")
-@click.option("--artifactory-api-key", required=True, help="Artifactory API key")
+@click.option("--artifactory-user-name", help="Artifactory user name")
+@click.option("--artifactory-api-key", help="Artifactory API key")
 @click.option(
     "--ibm-cloud-pak-for-data-entitlement-key",
     help="IBM Cloud Pak for Data entitlement key",
@@ -85,12 +85,7 @@ def install_db2(
 ):
     """Install IBM Db2 or IBM Db2 Warehouse"""
 
-    if not use_dev and ibm_cloud_pak_for_data_entitlement_key is None:
-        raise click.UsageError(
-            "Missing option '--ibm-cloud-pak-for-data-entitlement-key'.",
-            ctx,
-        )
-
+    dg.lib.click.check_cloud_pak_for_data_options(ctx, use_dev, locals().copy())
     dg.lib.click.log_in_to_openshift_cluster(ctx, locals().copy())
 
     cloud_pak_for_data_manager = (

--- a/dg/config/__init__.py
+++ b/dg/config/__init__.py
@@ -22,11 +22,9 @@ from typing import Any, Union
 class DataGateConfigurationManager:
     """Manages the Data Gate CLI configuration"""
 
-    supported_true_boolean_values = ["true", "yes", "enable", "enabled", "active"]
-    supported_false_boolean_values = ["false", "no", "disable", "disabled", "inactive"]
-
-    def get_current_credentials(self) -> pathlib.Path:
-        """Returns user and current cluster credentials
+    def get_deps_directory_path(self) -> pathlib.Path:
+        """Returns the path of the directory containing required non-Python
+        files
 
         Returns
         -------
@@ -204,7 +202,6 @@ class DataGateConfigurationManager:
         -------
         bool
             true, if FYRE options shall be hidden in help texts
-            false if not
         """
 
         return not self.get_dg_bool_config_value("fyre_commands", False)
@@ -217,21 +214,19 @@ class DataGateConfigurationManager:
         -------
         bool
             true, if nuclear options shall be hidden in help texts
-            false if not
         """
 
         return not self.get_dg_bool_config_value("nuclear_commands", False)
 
     def get_dg_bool_config_value(self, key: str, default_value: bool) -> bool:
-        """Get the value for a given key from the dg configuration file
+        """Gets the value for a given key from the settings file
 
         Parameters
         ----------
         key
             name of the key of the value to get
-
         default_value
-            default_value value to use if key cannot be found in the config file
+            default value to use if key cannot be found in the settings file
         """
         result = default_value
 
@@ -241,41 +236,49 @@ class DataGateConfigurationManager:
             if key in settings:
                 value = str(settings[key])
 
-                if value.lower() in self.supported_true_boolean_values:
+                if (
+                    value.lower()
+                    in DataGateConfigurationManager._supported_true_boolean_values
+                ):
                     result = True
-                elif value.lower() in self.supported_false_boolean_values:
+                elif (
+                    value.lower()
+                    in DataGateConfigurationManager._supported_false_boolean_values
+                ):
                     result = False
                 else:
                     raise Exception(
                         f"Expected value of configuration parameter '{key}' must be a boolean of the form "
-                        f"[{', '.join(self.supported_true_boolean_values)}] or "
-                        f"[{', '.join(self.supported_false_boolean_values)}] but found '{value}'."
+                        f"[{', '.join(DataGateConfigurationManager._supported_true_boolean_values)}] or "
+                        f"[{', '.join(DataGateConfigurationManager._supported_false_boolean_values)}] but found "
+                        f"'{value}'."
                     )
 
         return result
 
     def set_dg_bool_config_value(self, key: str, value: str):
-        """Set a given key:value pair in the dg configuration file
+        """Sets a given key:value pair in the settings file
 
         Parameters
         ----------
         key
             name of the key to set
-
         value
             value to be set for key
         """
 
-        if (
-            value.lower() not in (self.supported_true_boolean_values + self.supported_false_boolean_values)
+        if value.lower() not in (
+            DataGateConfigurationManager._supported_true_boolean_values
+            + DataGateConfigurationManager._supported_false_boolean_values
         ):
             raise Exception(
                 f"Passed value '{value}' for '{key}' must be a boolean of the form "
-                f"[{', '.join(self.supported_true_boolean_values)}] or "
-                f"[{', '.join(self.supported_false_boolean_values)}]."
+                f"[{', '.join(DataGateConfigurationManager._supported_true_boolean_values)}] or "
+                f"[{', '.join(DataGateConfigurationManager._supported_false_boolean_values)}]."
             )
 
         settings = {}
+
         if self.get_dg_settings_file_path().exists():
             settings = json.loads(self.get_dg_settings_file_path().read_text())
 
@@ -285,6 +288,9 @@ class DataGateConfigurationManager:
 
         with open(self.get_dg_settings_file_path(), "w+") as f:
             f.write(json.dumps(settings, indent=4))
+
+    _supported_false_boolean_values = ["disable", "disabled", "false", "inactive" "no"]
+    _supported_true_boolean_values = ["active", "enable", "enabled", "true", "yes"]
 
 
 data_gate_configuration_manager = DataGateConfigurationManager()

--- a/dg/lib/click.py
+++ b/dg/lib/click.py
@@ -26,6 +26,49 @@ import dg.config.cluster_credentials_manager
 import dg.lib.openshift
 
 
+def check_cloud_pak_for_data_options(
+    ctx: click.Context, use_dev: bool, options: dict[str, Any]
+):
+    """Checks if values for required Click options were passed to a Click
+    command to install an IBM Cloud Pak for Data assembly
+
+    Parameters
+    ----------
+    use_dev
+        flag indicating whether a development build of an IBM Cloud Pak for Data
+        assembly shall be installed
+    options
+        options passed to a Click command
+    """
+
+    if use_dev:
+        if (
+            ("artifactory_user_name" in options)
+            and (options["artifactory_user_name"] is None)
+            and ("artifactory_api_key" in options)
+            and (options["artifactory_api_key"] is None)
+        ):
+            raise click.UsageError(
+                "Missing options '--artifactory-user-name' and '--artifactory-api-key'",
+                ctx,
+            )
+        elif ("artifactory_user_name" in options) and (
+            options["artifactory_user_name"] is None
+        ):
+            raise click.UsageError("Missing option '--artifactory-user-name'", ctx)
+        elif ("artifactory_api_key" in options) and (
+            options["artifactory_api_key"] is None
+        ):
+            raise click.UsageError("Missing option '--artifactory-api-key'", ctx)
+    else:
+        if ("ibm_cloud_pak_for_data_entitlement_key" in options) and (
+            options["ibm_cloud_pak_for_data_entitlement_key"] is None
+        ):
+            raise click.UsageError(
+                "Missing option '--ibm-cloud-pak-for-data-entitlement-key'", ctx
+            )
+
+
 def create_click_multi_command_class(
     modules: dict[str, ModuleType]
 ) -> type[click.Command]:

--- a/dg/lib/click.py
+++ b/dg/lib/click.py
@@ -25,23 +25,26 @@ import click
 import dg.config.cluster_credentials_manager
 import dg.lib.openshift
 
+from dg.lib.cloud_pak_for_data.cpd_manager import CloudPakForDataAssemblyBuildType
+
 
 def check_cloud_pak_for_data_options(
-    ctx: click.Context, use_dev: bool, options: dict[str, Any]
+    ctx: click.Context,
+    build_type: CloudPakForDataAssemblyBuildType,
+    options: dict[str, Any],
 ):
     """Checks if values for required Click options were passed to a Click
     command to install an IBM Cloud Pak for Data assembly
 
     Parameters
     ----------
-    use_dev
-        flag indicating whether a development build of an IBM Cloud Pak for Data
-        assembly shall be installed
+    build_type
+        build type of an IBM Cloud Pak for Data assembly to be installed
     options
         options passed to a Click command
     """
 
-    if use_dev:
+    if build_type == CloudPakForDataAssemblyBuildType.DEV:
         if (
             ("artifactory_user_name" in options)
             and (options["artifactory_user_name"] is None)

--- a/dg/lib/cloud_pak_for_data/cpd_3_0_1/cpd_manager.py
+++ b/dg/lib/cloud_pak_for_data/cpd_3_0_1/cpd_manager.py
@@ -36,6 +36,7 @@ import dg.utils.operating_system
 from dg.config.binaries_manager import binaries_manager
 from dg.lib.cloud_pak_for_data.cpd_manager import (
     AbstractCloudPakForDataManager,
+    CloudPakForDataAssemblyBuildType,
     CloudPakForDataVersion,
 )
 
@@ -43,8 +44,8 @@ from dg.lib.cloud_pak_for_data.cpd_manager import (
 class CloudPakForDataManager(AbstractCloudPakForDataManager):
     """IBM Cloud Pak for Data 3.0.1 management class"""
 
-    def __init__(self, use_dev: bool):
-        super().__init__(use_dev)
+    def __init__(self, build_type: CloudPakForDataAssemblyBuildType):
+        super().__init__(build_type)
 
         self._cloud_pak_for_data_version = semver.VersionInfo.parse("3.0.1")
 
@@ -56,7 +57,7 @@ class CloudPakForDataManager(AbstractCloudPakForDataManager):
             ]
         )
 
-        if self._use_dev:
+        if self._build_type == CloudPakForDataAssemblyBuildType.DEV:
             directory_alias = cloud_pak_for_data_version["development"][
                 "directory_alias"
             ]
@@ -124,7 +125,7 @@ class CloudPakForDataManager(AbstractCloudPakForDataManager):
 
         self.execute_cloud_pak_for_data_installer(args)
 
-        if self._use_dev:
+        if self._build_type == CloudPakForDataAssemblyBuildType.DEV:
             # install assembly
             args = [
                 "--accept-all-licenses",

--- a/dg/lib/cloud_pak_for_data/cpd_3_5_0/cpd_manager.py
+++ b/dg/lib/cloud_pak_for_data/cpd_3_5_0/cpd_manager.py
@@ -34,6 +34,7 @@ import dg.utils.operating_system
 from dg.config.binaries_manager import binaries_manager
 from dg.lib.cloud_pak_for_data.cpd_manager import (
     AbstractCloudPakForDataManager,
+    CloudPakForDataAssemblyBuildType,
     CloudPakForDataVersion,
 )
 from dg.utils.operating_system import OperatingSystem
@@ -57,8 +58,8 @@ cloud_pak_for_data_configuration_data_dict = {
 class CloudPakForDataManager(AbstractCloudPakForDataManager):
     """IBM Cloud Pak for Data 3.5.0 management class"""
 
-    def __init__(self, use_dev: bool):
-        super().__init__(use_dev)
+    def __init__(self, build_type: CloudPakForDataAssemblyBuildType):
+        super().__init__(build_type)
 
         self._cloud_pak_for_data_version = semver.VersionInfo.parse("3.5.0")
 
@@ -70,7 +71,7 @@ class CloudPakForDataManager(AbstractCloudPakForDataManager):
             ]
         )
 
-        if self._use_dev:
+        if self._build_type == CloudPakForDataAssemblyBuildType.DEV:
             directory_alias = cloud_pak_for_data_version["development"][
                 "directory_alias"
             ]
@@ -142,7 +143,7 @@ class CloudPakForDataManager(AbstractCloudPakForDataManager):
 
         self.execute_cloud_pak_for_data_installer(args)
 
-        if self._use_dev:
+        if self._build_type == CloudPakForDataAssemblyBuildType.DEV:
             # install assembly
             args = [
                 "install",
@@ -268,12 +269,14 @@ class CloudPakForDataManager(AbstractCloudPakForDataManager):
 
         target_directory_path = (
             dg.config.data_gate_configuration_manager.get_dg_bin_directory_path()
-            / cloud_pak_for_data_version["development" if self._use_dev else "release"][
-                "directory_alias"
-            ]
+            / cloud_pak_for_data_version[
+                "development"
+                if self._build_type == CloudPakForDataAssemblyBuildType.DEV
+                else "release"
+            ]["directory_alias"]
         )
 
-        if self._use_dev:
+        if self._build_type == CloudPakForDataAssemblyBuildType.DEV:
             operating_system = dg.utils.operating_system.get_operating_system()
             cloud_pak_for_data_configuration_data = (
                 cloud_pak_for_data_configuration_data_dict[operating_system]

--- a/dg/lib/cloud_pak_for_data/cpd_manager.py
+++ b/dg/lib/cloud_pak_for_data/cpd_manager.py
@@ -20,6 +20,7 @@ import tempfile
 import urllib.parse
 
 from abc import ABC, abstractmethod
+from enum import Enum
 from typing import Any, TypedDict, Union
 
 import semver
@@ -32,6 +33,11 @@ import dg.utils.operating_system
 import dg.utils.process
 
 from dg.utils.operating_system import OperatingSystem
+
+
+class CloudPakForDataAssemblyBuildType(Enum):
+    DEV = 1
+    RELEASE = 2
 
 
 class CloudPakForDataVersion(TypedDict):
@@ -55,8 +61,8 @@ CloudPakForDataVersions = TypedDict(
 class AbstractCloudPakForDataManager(ABC):
     """Base class of all IBM Cloud Pak for Data management classes"""
 
-    def __init__(self, use_dev: bool):
-        self._use_dev = use_dev
+    def __init__(self, build_type: CloudPakForDataAssemblyBuildType):
+        self._build_type = build_type
 
     def check_openshift_version(self):
         cloud_pak_for_data_version = self._get_cloud_pak_for_data_version()
@@ -97,7 +103,7 @@ class AbstractCloudPakForDataManager(ABC):
 
         directory_alias = (
             cloud_pak_for_data_version["development"]["directory_alias"]
-            if self._use_dev
+            if self._build_type == CloudPakForDataAssemblyBuildType.DEV
             else cloud_pak_for_data_version["release"]["directory_alias"]
         )
 
@@ -204,7 +210,7 @@ class AbstractCloudPakForDataManager(ABC):
             assembly_name,
         )
 
-        if not self._use_dev:
+        if self._build_type == CloudPakForDataAssemblyBuildType.RELEASE:
             openshift_image_registry_route = (
                 dg.lib.openshift.get_openshift_image_registry_default_route()
             )
@@ -320,7 +326,7 @@ class AbstractCloudPakForDataManager(ABC):
             name of the assembly to be installed
         """
 
-        if self._use_dev:
+        if self._build_type == CloudPakForDataAssemblyBuildType.DEV:
             return self._prepare_yaml_file_for_development_build(
                 artifactory_user_name, artifactory_api_key, assembly_name
             )

--- a/dg/lib/cloud_pak_for_data/cpd_manager.py
+++ b/dg/lib/cloud_pak_for_data/cpd_manager.py
@@ -326,10 +326,7 @@ class AbstractCloudPakForDataManager(ABC):
             )
         else:
             return self._prepare_yaml_file_for_release_build(
-                artifactory_user_name,
-                artifactory_api_key,
-                ibm_cloud_pak_for_data_entitlement_key,
-                assembly_name,
+                ibm_cloud_pak_for_data_entitlement_key
             )
 
     @abstractmethod
@@ -422,10 +419,7 @@ class AbstractCloudPakForDataManager(ABC):
 
     def _prepare_yaml_file_for_release_build(
         self,
-        artifactory_user_name: str,
-        artifactory_api_key: str,
         ibm_cloud_pak_for_data_entitlement_key: Union[str, None],
-        assembly_name: str,
     ) -> pathlib.Path:
         """Prepares a YAML file for installing a release build of the assembly
         with the given name

--- a/dg/lib/download_manager/__init__.py
+++ b/dg/lib/download_manager/__init__.py
@@ -1,3 +1,17 @@
+#  Copyright 2020 IBM Corporation
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 from dg.lib.download_manager.download_manager import DownloadManager
 from dg.lib.download_manager.plugins.ibm_cloud_cli_plugin import (
     IBMCloudCLIPlugIn,

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
         "asyncssh",
         "click",
         "colorama",
+        "click-option-group",
         "pyyaml",
         "requests",
         "semver",


### PR DESCRIPTION
This pull request contains the following changes:

- Specify `--artifactory-user-name` and `--artifactory-api-key` as optional for the following commands:
  - `dg cluster install-assembly`
  - `dg cluster install-cloud-pak-for-data`
  - `dg cluster install-data-gate`
  - `dg cluster install-db2`