### PR TITLE
Fix IBM Cloud error during cluster creation

### DIFF
--- a/dg/commands/ibmcloud/cluster/create.py
+++ b/dg/commands/ibmcloud/cluster/create.py
@@ -95,7 +95,7 @@ def create(
         "--entitlement",
         "cloud_pak",
         "--flavor",
-        "b2c.16x64",
+        "b3c.16x64",
         "--hardware",
         "dedicated",
         "--name",


### PR DESCRIPTION
This pull request fixes the following error during cluster creation:

```
The specified flavor is deprecated. (E0146)

To list available flavors for a location, run 'ibmcloud ks flavors --zone <zone>'.
```

I looks like flavor `b2c.16x64` was replaced with flavor `b3c.16x64`.