### PR TITLE
Add support for cpd-cli 3.5.2

### DIFF
--- a/dg/lib/cloud_pak_for_data/cpd_3_5_0/cpd_manager.py
+++ b/dg/lib/cloud_pak_for_data/cpd_3_5_0/cpd_manager.py
@@ -393,7 +393,7 @@ class CloudPakForDataManager(AbstractCloudPakForDataManager):
 
         for release in response_json:
             search_result = re.search(
-                f".*({str(self._cloud_pak_for_data_version)}(-\\d+)*).*",
+                f".*({self._cloud_pak_for_data_version.major}\\.{self._cloud_pak_for_data_version.minor}\\.\\d+(-\\d+)*).*",
                 release["name"],
             )
 


### PR DESCRIPTION
This pull request contains the following changes:

- Add support for installing the [January 2021 refresh of Cloud Pak for Data 3.5.0](https://www.ibm.com/support/producthub/icpdata/docs/content/SSQNUZ_latest/cpd/overview/whats-new.html#whats-new__dec2020#whats-new__dec2020) using [Cloud Pak for Data 3.5.2 Installer](https://github.com/IBM/cpd-cli/releases/tag/v3.5.2).
- This change was tested using a FYRE cluster.