### PR TITLE
Improve logging infrastructure

### DIFF
--- a/dg/commands/adm/config/set.py
+++ b/dg/commands/adm/config/set.py
@@ -16,10 +16,10 @@ import click
 
 import dg.config
 
-from dg.utils.logging import loglevel_option
+from dg.utils.logging import loglevel_command
 
 
-@click.command()
+@loglevel_command()
 @click.option(
     "--key",
     required=True,
@@ -30,7 +30,6 @@ from dg.utils.logging import loglevel_option
     required=True,
     help="Value to which key should be set",
 )
-@loglevel_option()
 def set(key: str, value: str):
     """Set configuration value"""
 

--- a/dg/commands/adm/config/set.py
+++ b/dg/commands/adm/config/set.py
@@ -16,6 +16,8 @@ import click
 
 import dg.config
 
+from dg.utils.logging import loglevel_option
+
 
 @click.command()
 @click.option(
@@ -28,6 +30,7 @@ import dg.config
     required=True,
     help="Value to which key should be set",
 )
+@loglevel_option()
 def set(key: str, value: str):
     """Set configuration value"""
 

--- a/dg/commands/adm/download_dependencies.py
+++ b/dg/commands/adm/download_dependencies.py
@@ -16,8 +16,11 @@ import click
 
 import dg.lib.download_manager
 
+from dg.utils.logging import loglevel_option
+
 
 @click.command()
+@loglevel_option()
 def download_dependencies():
     """Download dependencies"""
 

--- a/dg/commands/adm/download_dependencies.py
+++ b/dg/commands/adm/download_dependencies.py
@@ -12,15 +12,12 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import click
-
 import dg.lib.download_manager
 
-from dg.utils.logging import loglevel_option
+from dg.utils.logging import loglevel_command
 
 
-@click.command()
-@loglevel_option()
+@loglevel_command()
 def download_dependencies():
     """Download dependencies"""
 

--- a/dg/commands/adm/store_credentials.py
+++ b/dg/commands/adm/store_credentials.py
@@ -18,6 +18,8 @@ import click
 
 import dg.config
 
+from dg.utils.logging import loglevel_option
+
 
 @click.command()
 @click.option("--artifactory-api-key", help="Artifactory API key")
@@ -28,6 +30,7 @@ import dg.config
     help="IBM Cloud Pak for Data entitlement key",
 )
 @click.option("--ibm-github-api-key", help="IBM GitHub API key")
+@loglevel_option()
 def store_credentials(
     artifactory_api_key: Union[str, None],
     artifactory_user_name: Union[str, None],

--- a/dg/commands/adm/store_credentials.py
+++ b/dg/commands/adm/store_credentials.py
@@ -18,10 +18,10 @@ import click
 
 import dg.config
 
-from dg.utils.logging import loglevel_option
+from dg.utils.logging import loglevel_command
 
 
-@click.command()
+@loglevel_command()
 @click.option("--artifactory-api-key", help="Artifactory API key")
 @click.option("--artifactory-user-name", help="Artifactory user name")
 @click.option("--ibm-cloud-api-key", help="IBM Cloud API key")
@@ -30,7 +30,6 @@ from dg.utils.logging import loglevel_option
     help="IBM Cloud Pak for Data entitlement key",
 )
 @click.option("--ibm-github-api-key", help="IBM GitHub API key")
-@loglevel_option()
 def store_credentials(
     artifactory_api_key: Union[str, None],
     artifactory_user_name: Union[str, None],

--- a/dg/commands/adm/update.py
+++ b/dg/commands/adm/update.py
@@ -19,8 +19,11 @@ from importlib import metadata
 
 import click
 
+from dg.utils.logging import loglevel_option
+
 
 @click.command()
+@loglevel_option()
 def update():
     """Update the Data Gate CLI to the latest version"""
 

--- a/dg/commands/adm/update.py
+++ b/dg/commands/adm/update.py
@@ -17,13 +17,10 @@ import subprocess
 
 from importlib import metadata
 
-import click
-
-from dg.utils.logging import loglevel_option
+from dg.utils.logging import loglevel_command
 
 
-@click.command()
-@loglevel_option()
+@loglevel_command()
 def update():
     """Update the Data Gate CLI to the latest version"""
 

--- a/dg/commands/cluster/current.py
+++ b/dg/commands/cluster/current.py
@@ -16,8 +16,11 @@ import click
 
 import dg.config.cluster_credentials_manager
 
+from dg.utils.logging import loglevel_option
+
 
 @click.command()
+@loglevel_option()
 def current():
     """Get the current registered OpenShift cluster"""
 

--- a/dg/commands/cluster/current.py
+++ b/dg/commands/cluster/current.py
@@ -16,11 +16,10 @@ import click
 
 import dg.config.cluster_credentials_manager
 
-from dg.utils.logging import loglevel_option
+from dg.utils.logging import loglevel_command
 
 
-@click.command()
-@loglevel_option()
+@loglevel_command()
 def current():
     """Get the current registered OpenShift cluster"""
 

--- a/dg/commands/cluster/edit.py
+++ b/dg/commands/cluster/edit.py
@@ -16,14 +16,13 @@ import click
 
 import dg.config.cluster_credentials_manager
 
-from dg.utils.logging import loglevel_option
+from dg.utils.logging import loglevel_command
 
 
-@click.command()
+@loglevel_command()
 @click.argument("alias_or_server")
 @click.option("--alias", help="Alias")
 @click.option("--password", help="kubeadmin password")
-@loglevel_option()
 def edit(alias_or_server: str, alias: str, password: str):
     """Edit metadata of a registered OpenShift cluster"""
 

--- a/dg/commands/cluster/edit.py
+++ b/dg/commands/cluster/edit.py
@@ -16,11 +16,14 @@ import click
 
 import dg.config.cluster_credentials_manager
 
+from dg.utils.logging import loglevel_option
+
 
 @click.command()
 @click.argument("alias_or_server")
 @click.option("--alias", help="Alias")
 @click.option("--password", help="kubeadmin password")
+@loglevel_option()
 def edit(alias_or_server: str, alias: str, password: str):
     """Edit metadata of a registered OpenShift cluster"""
 

--- a/dg/commands/cluster/install_assembly.py
+++ b/dg/commands/cluster/install_assembly.py
@@ -31,10 +31,10 @@ from dg.lib.cloud_pak_for_data.cpd_manager import (
 from dg.lib.cloud_pak_for_data.cpd_manager_factory import (
     CloudPakForDataManagerFactory,
 )
-from dg.utils.logging import loglevel_option
+from dg.utils.logging import loglevel_command
 
 
-@click.command(
+@loglevel_command(
     context_settings=dg.lib.click.create_default_map_from_dict(
         dg.config.cluster_credentials_manager.cluster_credentials_manager.get_current_credentials()
     )
@@ -74,7 +74,6 @@ from dg.utils.logging import loglevel_option
 @optgroup.group("Development build options")
 @optgroup.option("--artifactory-user-name", help="Artifactory user name")
 @optgroup.option("--artifactory-api-key", help="Artifactory API key")
-@loglevel_option()
 @click.pass_context
 def install_assembly(
     ctx: click.Context,

--- a/dg/commands/cluster/install_assembly.py
+++ b/dg/commands/cluster/install_assembly.py
@@ -31,6 +31,7 @@ from dg.lib.cloud_pak_for_data.cpd_manager import (
 from dg.lib.cloud_pak_for_data.cpd_manager_factory import (
     CloudPakForDataManagerFactory,
 )
+from dg.utils.logging import loglevel_option
 
 
 @click.command(
@@ -73,6 +74,7 @@ from dg.lib.cloud_pak_for_data.cpd_manager_factory import (
 @optgroup.group("Development build options")
 @optgroup.option("--artifactory-user-name", help="Artifactory user name")
 @optgroup.option("--artifactory-api-key", help="Artifactory API key")
+@loglevel_option()
 @click.pass_context
 def install_assembly(
     ctx: click.Context,

--- a/dg/commands/cluster/install_cloud_pak_for_data.py
+++ b/dg/commands/cluster/install_cloud_pak_for_data.py
@@ -33,6 +33,7 @@ from dg.lib.cloud_pak_for_data.cpd_manager import (
 from dg.lib.cloud_pak_for_data.cpd_manager_factory import (
     CloudPakForDataManagerFactory,
 )
+from dg.utils.logging import loglevel_option
 
 
 @click.command(
@@ -72,6 +73,7 @@ from dg.lib.cloud_pak_for_data.cpd_manager_factory import (
 @optgroup.group("Development build options")
 @optgroup.option("--artifactory-user-name", help="Artifactory user name")
 @optgroup.option("--artifactory-api-key", help="Artifactory API key")
+@loglevel_option()
 @click.pass_context
 def install_cloud_pak_for_data(
     ctx: click.Context,

--- a/dg/commands/cluster/install_cloud_pak_for_data.py
+++ b/dg/commands/cluster/install_cloud_pak_for_data.py
@@ -33,10 +33,10 @@ from dg.lib.cloud_pak_for_data.cpd_manager import (
 from dg.lib.cloud_pak_for_data.cpd_manager_factory import (
     CloudPakForDataManagerFactory,
 )
-from dg.utils.logging import loglevel_option
+from dg.utils.logging import loglevel_command
 
 
-@click.command(
+@loglevel_command(
     context_settings=dg.lib.click.create_default_map_from_dict(
         dg.config.cluster_credentials_manager.cluster_credentials_manager.get_current_credentials()
     )
@@ -73,7 +73,6 @@ from dg.utils.logging import loglevel_option
 @optgroup.group("Development build options")
 @optgroup.option("--artifactory-user-name", help="Artifactory user name")
 @optgroup.option("--artifactory-api-key", help="Artifactory API key")
-@loglevel_option()
 @click.pass_context
 def install_cloud_pak_for_data(
     ctx: click.Context,

--- a/dg/commands/cluster/install_data_gate.py
+++ b/dg/commands/cluster/install_data_gate.py
@@ -31,6 +31,7 @@ from dg.lib.cloud_pak_for_data.cpd_manager import (
 from dg.lib.cloud_pak_for_data.cpd_manager_factory import (
     CloudPakForDataManagerFactory,
 )
+from dg.utils.logging import loglevel_option
 
 
 @click.command(
@@ -70,6 +71,7 @@ from dg.lib.cloud_pak_for_data.cpd_manager_factory import (
 @optgroup.group("Development build options")
 @optgroup.option("--artifactory-user-name", help="Artifactory user name")
 @optgroup.option("--artifactory-api-key", help="Artifactory API key")
+@loglevel_option()
 @click.pass_context
 def install_data_gate(
     ctx: click.Context,

--- a/dg/commands/cluster/install_data_gate.py
+++ b/dg/commands/cluster/install_data_gate.py
@@ -31,10 +31,10 @@ from dg.lib.cloud_pak_for_data.cpd_manager import (
 from dg.lib.cloud_pak_for_data.cpd_manager_factory import (
     CloudPakForDataManagerFactory,
 )
-from dg.utils.logging import loglevel_option
+from dg.utils.logging import loglevel_command
 
 
-@click.command(
+@loglevel_command(
     context_settings=dg.lib.click.create_default_map_from_dict(
         dg.config.cluster_credentials_manager.cluster_credentials_manager.get_current_credentials()
     )
@@ -71,7 +71,6 @@ from dg.utils.logging import loglevel_option
 @optgroup.group("Development build options")
 @optgroup.option("--artifactory-user-name", help="Artifactory user name")
 @optgroup.option("--artifactory-api-key", help="Artifactory API key")
-@loglevel_option()
 @click.pass_context
 def install_data_gate(
     ctx: click.Context,

--- a/dg/commands/cluster/install_db2.py
+++ b/dg/commands/cluster/install_db2.py
@@ -32,6 +32,7 @@ from dg.lib.cloud_pak_for_data.cpd_manager import (
 from dg.lib.cloud_pak_for_data.cpd_manager_factory import (
     CloudPakForDataManagerFactory,
 )
+from dg.utils.logging import loglevel_option
 
 
 @click.command(
@@ -77,6 +78,7 @@ from dg.lib.cloud_pak_for_data.cpd_manager_factory import (
 @optgroup.group("Development build options")
 @optgroup.option("--artifactory-user-name", help="Artifactory user name")
 @optgroup.option("--artifactory-api-key", help="Artifactory API key")
+@loglevel_option()
 @click.pass_context
 def install_db2(
     ctx: click.Context,

--- a/dg/commands/cluster/install_db2.py
+++ b/dg/commands/cluster/install_db2.py
@@ -32,10 +32,10 @@ from dg.lib.cloud_pak_for_data.cpd_manager import (
 from dg.lib.cloud_pak_for_data.cpd_manager_factory import (
     CloudPakForDataManagerFactory,
 )
-from dg.utils.logging import loglevel_option
+from dg.utils.logging import loglevel_command
 
 
-@click.command(
+@loglevel_command(
     context_settings=dg.lib.click.create_default_map_from_dict(
         dg.config.cluster_credentials_manager.cluster_credentials_manager.get_current_credentials()
     )
@@ -78,7 +78,6 @@ from dg.utils.logging import loglevel_option
 @optgroup.group("Development build options")
 @optgroup.option("--artifactory-user-name", help="Artifactory user name")
 @optgroup.option("--artifactory-api-key", help="Artifactory API key")
-@loglevel_option()
 @click.pass_context
 def install_db2(
     ctx: click.Context,

--- a/dg/commands/cluster/login.py
+++ b/dg/commands/cluster/login.py
@@ -12,23 +12,20 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import click
-
 import dg.config.cluster_credentials_manager
 import dg.lib.click
 import dg.lib.fyre.cluster.fyre_cluster_factory  # required to register FYREClusterFactory object
 import dg.lib.ibmcloud.cluster.ibmcloud_cluster_factory  # required to register IBMCloudClusterFactory object
 
 from dg.lib.error import DataGateCLIException
-from dg.utils.logging import loglevel_option
+from dg.utils.logging import loglevel_command
 
 
-@click.command(
+@loglevel_command(
     context_settings=dg.lib.click.create_default_map_from_dict(
         dg.config.cluster_credentials_manager.cluster_credentials_manager.get_current_credentials()
     )
 )
-@loglevel_option()
 def login():
     """Log in to the current OpenShift cluster"""
 

--- a/dg/commands/cluster/login.py
+++ b/dg/commands/cluster/login.py
@@ -20,6 +20,7 @@ import dg.lib.fyre.cluster.fyre_cluster_factory  # required to register FYREClus
 import dg.lib.ibmcloud.cluster.ibmcloud_cluster_factory  # required to register IBMCloudClusterFactory object
 
 from dg.lib.error import DataGateCLIException
+from dg.utils.logging import loglevel_option
 
 
 @click.command(
@@ -27,6 +28,7 @@ from dg.lib.error import DataGateCLIException
         dg.config.cluster_credentials_manager.cluster_credentials_manager.get_current_credentials()
     )
 )
+@loglevel_option()
 def login():
     """Log in to the current OpenShift cluster"""
 

--- a/dg/commands/cluster/ls.py
+++ b/dg/commands/cluster/ls.py
@@ -16,8 +16,11 @@ import click
 
 import dg.config.cluster_credentials_manager
 
+from dg.utils.logging import loglevel_option
+
 
 @click.command()
+@loglevel_option()
 def ls():
     """List registered OpenShift clusters"""
 

--- a/dg/commands/cluster/ls.py
+++ b/dg/commands/cluster/ls.py
@@ -16,11 +16,10 @@ import click
 
 import dg.config.cluster_credentials_manager
 
-from dg.utils.logging import loglevel_option
+from dg.utils.logging import loglevel_command
 
 
-@click.command()
-@loglevel_option()
+@loglevel_command()
 def ls():
     """List registered OpenShift clusters"""
 

--- a/dg/commands/cluster/rm.py
+++ b/dg/commands/cluster/rm.py
@@ -16,8 +16,11 @@ import click
 
 import dg.config.cluster_credentials_manager
 
+from dg.utils.logging import loglevel_option
+
 
 @click.command()
+@loglevel_option()
 @click.argument("alias_or_server")
 def rm(alias_or_server: str):
     """Remove a registered OpenShift cluster"""

--- a/dg/commands/cluster/rm.py
+++ b/dg/commands/cluster/rm.py
@@ -16,11 +16,10 @@ import click
 
 import dg.config.cluster_credentials_manager
 
-from dg.utils.logging import loglevel_option
+from dg.utils.logging import loglevel_command
 
 
-@click.command()
-@loglevel_option()
+@loglevel_command()
 @click.argument("alias_or_server")
 def rm(alias_or_server: str):
     """Remove a registered OpenShift cluster"""

--- a/dg/commands/cluster/use.py
+++ b/dg/commands/cluster/use.py
@@ -16,11 +16,10 @@ import click
 
 import dg.config.cluster_credentials_manager
 
-from dg.utils.logging import loglevel_option
+from dg.utils.logging import loglevel_command
 
 
-@click.command()
-@loglevel_option()
+@loglevel_command()
 @click.argument("alias_or_server")
 def use(alias_or_server: str):
     """Set the current registered OpenShift cluster"""

--- a/dg/commands/cluster/use.py
+++ b/dg/commands/cluster/use.py
@@ -16,8 +16,11 @@ import click
 
 import dg.config.cluster_credentials_manager
 
+from dg.utils.logging import loglevel_option
+
 
 @click.command()
+@loglevel_option()
 @click.argument("alias_or_server")
 def use(alias_or_server: str):
     """Set the current registered OpenShift cluster"""

--- a/dg/commands/fyre/cluster/add.py
+++ b/dg/commands/fyre/cluster/add.py
@@ -17,10 +17,10 @@ import click
 import dg.config.cluster_credentials_manager
 import dg.lib.fyre.cluster
 
-from dg.utils.logging import loglevel_option
+from dg.utils.logging import loglevel_command
 
 
-@click.command()
+@loglevel_command()
 @click.option(
     "--alias", help="Alias used to reference a cluster instead of its server URL"
 )
@@ -30,7 +30,6 @@ from dg.utils.logging import loglevel_option
     help="Name of the OpenShift cluster to be registered",
 )
 @click.option("--password", required=True, help="kubeadmin password")
-@loglevel_option()
 def add(cluster_name: str, alias: str, password: str):
     """Register an existing OpenShift cluster on FYRE"""
 

--- a/dg/commands/fyre/cluster/add.py
+++ b/dg/commands/fyre/cluster/add.py
@@ -17,6 +17,8 @@ import click
 import dg.config.cluster_credentials_manager
 import dg.lib.fyre.cluster
 
+from dg.utils.logging import loglevel_option
+
 
 @click.command()
 @click.option(
@@ -28,6 +30,7 @@ import dg.lib.fyre.cluster
     help="Name of the OpenShift cluster to be registered",
 )
 @click.option("--password", required=True, help="kubeadmin password")
+@loglevel_option()
 def add(cluster_name: str, alias: str, password: str):
     """Register an existing OpenShift cluster on FYRE"""
 

--- a/dg/commands/fyre/cluster/copy_ssh_key.py
+++ b/dg/commands/fyre/cluster/copy_ssh_key.py
@@ -19,10 +19,10 @@ import click
 import dg.config.cluster_credentials_manager
 import dg.lib.click
 
-from dg.utils.logging import loglevel_option
+from dg.utils.logging import loglevel_command
 
 
-@click.command(
+@loglevel_command(
     context_settings=dg.lib.click.create_default_map_from_dict(
         dg.config.cluster_credentials_manager.cluster_credentials_manager.get_current_credentials()
     )
@@ -30,7 +30,6 @@ from dg.utils.logging import loglevel_option
 @click.option(
     "--infrastructure-node-hostname", required=True, help="Infrastructure node hostname"
 )
-@loglevel_option()
 def copy_ssh_key(infrastructure_node_hostname: str):
     """Copy the current user's public SSH key to the infrastructure node"""
 

--- a/dg/commands/fyre/cluster/copy_ssh_key.py
+++ b/dg/commands/fyre/cluster/copy_ssh_key.py
@@ -19,6 +19,8 @@ import click
 import dg.config.cluster_credentials_manager
 import dg.lib.click
 
+from dg.utils.logging import loglevel_option
+
 
 @click.command(
     context_settings=dg.lib.click.create_default_map_from_dict(
@@ -28,6 +30,7 @@ import dg.lib.click
 @click.option(
     "--infrastructure-node-hostname", required=True, help="Infrastructure node hostname"
 )
+@loglevel_option()
 def copy_ssh_key(infrastructure_node_hostname: str):
     """Copy the current user's public SSH key to the infrastructure node"""
 

--- a/dg/commands/fyre/cluster/create.py
+++ b/dg/commands/fyre/cluster/create.py
@@ -24,6 +24,7 @@ import dg.lib.click
 import dg.utils.network
 
 from dg.lib.error import DataGateCLIException
+from dg.utils.logging import loglevel_option
 
 IBM_FYRE_DEPLOY_OPENSHIFT_CLUSTER_URL: Final[
     str
@@ -42,6 +43,7 @@ IBM_FYRE_DEPLOY_OPENSHIFT_CLUSTER_URL: Final[
 )
 @click.option("--fyre-user-name", required=True, help="Fyre API user name")
 @click.option("--fyre-api-key", required=True, help="Fyre API key")
+@loglevel_option()
 def create(cluster_name: str, fyre_user_name: str, fyre_api_key: str):
     """Create a new OpenShift cluster on FYRE"""
 

--- a/dg/commands/fyre/cluster/create.py
+++ b/dg/commands/fyre/cluster/create.py
@@ -24,14 +24,14 @@ import dg.lib.click
 import dg.utils.network
 
 from dg.lib.error import DataGateCLIException
-from dg.utils.logging import loglevel_option
+from dg.utils.logging import loglevel_command
 
 IBM_FYRE_DEPLOY_OPENSHIFT_CLUSTER_URL: Final[
     str
 ] = "https://api.fyre.ibm.com/rest/v1/?operation=deployopenshiftcluster"
 
 
-@click.command(
+@loglevel_command(
     context_settings=dg.lib.click.create_default_map_from_json_file(
         dg.config.data_gate_configuration_manager.get_dg_credentials_file_path()
     )
@@ -43,7 +43,6 @@ IBM_FYRE_DEPLOY_OPENSHIFT_CLUSTER_URL: Final[
 )
 @click.option("--fyre-user-name", required=True, help="Fyre API user name")
 @click.option("--fyre-api-key", required=True, help="Fyre API key")
-@loglevel_option()
 def create(cluster_name: str, fyre_user_name: str, fyre_api_key: str):
     """Create a new OpenShift cluster on FYRE"""
 

--- a/dg/commands/fyre/cluster/get_cluster_access_token.py
+++ b/dg/commands/fyre/cluster/get_cluster_access_token.py
@@ -18,6 +18,7 @@ import dg.config.cluster_credentials_manager
 import dg.lib.click
 
 from dg.lib.fyre.cluster.fyre_cluster_factory import fyre_cluster_factory
+from dg.utils.logging import loglevel_option
 
 
 @click.command(
@@ -37,6 +38,7 @@ from dg.lib.fyre.cluster.fyre_cluster_factory import fyre_cluster_factory
     help="Print oc login command instead of just the OAuth access token",
     is_flag=True,
 )
+@loglevel_option()
 @click.pass_context
 def get_cluster_access_token(
     ctx: click.Context,

--- a/dg/commands/fyre/cluster/get_cluster_access_token.py
+++ b/dg/commands/fyre/cluster/get_cluster_access_token.py
@@ -18,10 +18,10 @@ import dg.config.cluster_credentials_manager
 import dg.lib.click
 
 from dg.lib.fyre.cluster.fyre_cluster_factory import fyre_cluster_factory
-from dg.utils.logging import loglevel_option
+from dg.utils.logging import loglevel_command
 
 
-@click.command(
+@loglevel_command(
     context_settings=dg.lib.click.create_default_map_from_dict(
         dg.config.cluster_credentials_manager.cluster_credentials_manager.get_current_credentials()
     )
@@ -38,7 +38,6 @@ from dg.utils.logging import loglevel_option
     help="Print oc login command instead of just the OAuth access token",
     is_flag=True,
 )
-@loglevel_option()
 @click.pass_context
 def get_cluster_access_token(
     ctx: click.Context,

--- a/dg/commands/fyre/cluster/init_node_for_data_gate.py
+++ b/dg/commands/fyre/cluster/init_node_for_data_gate.py
@@ -21,10 +21,10 @@ import dg.config.cluster_credentials_manager
 import dg.lib.click
 import dg.utils.ssh
 
-from dg.utils.logging import loglevel_option
+from dg.utils.logging import loglevel_command
 
 
-@click.command(
+@loglevel_command(
     context_settings=dg.lib.click.create_default_map_from_dict(
         dg.config.cluster_credentials_manager.cluster_credentials_manager.get_current_credentials()
     )
@@ -33,7 +33,6 @@ from dg.utils.logging import loglevel_option
     "--infrastructure-node-hostname", required=True, help="Infrastructure node hostname"
 )
 @click.option("--node", required=True, help="Worker node to be initialized")
-@loglevel_option()
 def init_node_for_data_gate(
     infrastructure_node_hostname: str,
     node: str,

--- a/dg/commands/fyre/cluster/init_node_for_data_gate.py
+++ b/dg/commands/fyre/cluster/init_node_for_data_gate.py
@@ -21,6 +21,8 @@ import dg.config.cluster_credentials_manager
 import dg.lib.click
 import dg.utils.ssh
 
+from dg.utils.logging import loglevel_option
+
 
 @click.command(
     context_settings=dg.lib.click.create_default_map_from_dict(
@@ -31,6 +33,7 @@ import dg.utils.ssh
     "--infrastructure-node-hostname", required=True, help="Infrastructure node hostname"
 )
 @click.option("--node", required=True, help="Worker node to be initialized")
+@loglevel_option()
 def init_node_for_data_gate(
     infrastructure_node_hostname: str,
     node: str,

--- a/dg/commands/fyre/cluster/init_node_for_db2.py
+++ b/dg/commands/fyre/cluster/init_node_for_db2.py
@@ -23,6 +23,8 @@ import dg.lib.click
 import dg.lib.fyre.openshift
 import dg.utils.network
 
+from dg.utils.logging import loglevel_option
+
 
 @click.command(
     context_settings=dg.lib.click.create_default_map_from_dict(
@@ -46,6 +48,7 @@ import dg.utils.network
     help="Db2 edition",
 )
 @click.option("--use-host-path-storage", is_flag=True, help="Use hostpath storage")
+@loglevel_option()
 @click.pass_context
 def init_node_for_db2(
     ctx: click.Context,

--- a/dg/commands/fyre/cluster/init_node_for_db2.py
+++ b/dg/commands/fyre/cluster/init_node_for_db2.py
@@ -23,10 +23,10 @@ import dg.lib.click
 import dg.lib.fyre.openshift
 import dg.utils.network
 
-from dg.utils.logging import loglevel_option
+from dg.utils.logging import loglevel_command
 
 
-@click.command(
+@loglevel_command(
     context_settings=dg.lib.click.create_default_map_from_dict(
         dg.config.cluster_credentials_manager.cluster_credentials_manager.get_current_credentials()
     )
@@ -48,7 +48,6 @@ from dg.utils.logging import loglevel_option
     help="Db2 edition",
 )
 @click.option("--use-host-path-storage", is_flag=True, help="Use hostpath storage")
-@loglevel_option()
 @click.pass_context
 def init_node_for_db2(
     ctx: click.Context,

--- a/dg/commands/fyre/cluster/install_nfs_storage_class.py
+++ b/dg/commands/fyre/cluster/install_nfs_storage_class.py
@@ -23,10 +23,10 @@ import dg.lib.click
 import dg.lib.fyre.nfs
 import dg.utils.network
 
-from dg.utils.logging import loglevel_option
+from dg.utils.logging import loglevel_command
 
 
-@click.command(
+@loglevel_command(
     context_settings=dg.lib.click.create_default_map_from_dict(
         dg.config.cluster_credentials_manager.cluster_credentials_manager.get_current_credentials()
     )
@@ -43,7 +43,6 @@ from dg.utils.logging import loglevel_option
 @click.option("--username", help="OpenShift username")
 @click.option("--password", help="OpenShift password")
 @click.option("--token", help="OpenShift OAuth access token")
-@loglevel_option()
 @click.pass_context
 def install_nfs_storage_class(
     ctx: click.Context,

--- a/dg/commands/fyre/cluster/install_nfs_storage_class.py
+++ b/dg/commands/fyre/cluster/install_nfs_storage_class.py
@@ -23,6 +23,8 @@ import dg.lib.click
 import dg.lib.fyre.nfs
 import dg.utils.network
 
+from dg.utils.logging import loglevel_option
+
 
 @click.command(
     context_settings=dg.lib.click.create_default_map_from_dict(
@@ -41,6 +43,7 @@ import dg.utils.network
 @click.option("--username", help="OpenShift username")
 @click.option("--password", help="OpenShift password")
 @click.option("--token", help="OpenShift OAuth access token")
+@loglevel_option()
 @click.pass_context
 def install_nfs_storage_class(
     ctx: click.Context,

--- a/dg/commands/fyre/cluster/login.py
+++ b/dg/commands/fyre/cluster/login.py
@@ -20,10 +20,10 @@ import dg.config.cluster_credentials_manager
 import dg.lib.click
 
 from dg.lib.fyre.cluster.fyre_cluster_factory import fyre_cluster_factory
-from dg.utils.logging import loglevel_option
+from dg.utils.logging import loglevel_command
 
 
-@click.command(
+@loglevel_command(
     context_settings=dg.lib.click.create_default_map_from_dict(
         dg.config.cluster_credentials_manager.cluster_credentials_manager.get_current_credentials()
     )
@@ -31,7 +31,6 @@ from dg.utils.logging import loglevel_option
 @click.option("--cluster-name", required=True, help="cluster name")
 @click.option("--username", help="OpenShift username")
 @click.option("--password", help="OpenShift password")
-@loglevel_option()
 @click.pass_context
 def login(
     ctx: click.Context,

--- a/dg/commands/fyre/cluster/login.py
+++ b/dg/commands/fyre/cluster/login.py
@@ -20,6 +20,7 @@ import dg.config.cluster_credentials_manager
 import dg.lib.click
 
 from dg.lib.fyre.cluster.fyre_cluster_factory import fyre_cluster_factory
+from dg.utils.logging import loglevel_option
 
 
 @click.command(
@@ -30,6 +31,7 @@ from dg.lib.fyre.cluster.fyre_cluster_factory import fyre_cluster_factory
 @click.option("--cluster-name", required=True, help="cluster name")
 @click.option("--username", help="OpenShift username")
 @click.option("--password", help="OpenShift password")
+@loglevel_option()
 @click.pass_context
 def login(
     ctx: click.Context,

--- a/dg/commands/fyre/cluster/ls.py
+++ b/dg/commands/fyre/cluster/ls.py
@@ -24,21 +24,20 @@ import dg.lib.click
 import dg.utils.network
 
 from dg.lib.error import DataGateCLIException
-from dg.utils.logging import loglevel_option
+from dg.utils.logging import loglevel_command
 
 IBM_FYRE_SHOW_OPENSHIFT_CLUSTERS_URL: Final[
     str
 ] = "https://api.fyre.ibm.com/rest/v1/?operation=query&request=showclusters"
 
 
-@click.command(
+@loglevel_command(
     context_settings=dg.lib.click.create_default_map_from_json_file(
         dg.config.data_gate_configuration_manager.get_dg_credentials_file_path()
     )
 )
 @click.option("--fyre-user-name", required=True, help="Fyre API user name")
 @click.option("--fyre-api-key", required=True, help="Fyre API key")
-@loglevel_option()
 def ls(fyre_user_name: str, fyre_api_key: str):
     """List OpenShift clusters on FYRE"""
 

--- a/dg/commands/fyre/cluster/ls.py
+++ b/dg/commands/fyre/cluster/ls.py
@@ -24,6 +24,7 @@ import dg.lib.click
 import dg.utils.network
 
 from dg.lib.error import DataGateCLIException
+from dg.utils.logging import loglevel_option
 
 IBM_FYRE_SHOW_OPENSHIFT_CLUSTERS_URL: Final[
     str
@@ -37,6 +38,7 @@ IBM_FYRE_SHOW_OPENSHIFT_CLUSTERS_URL: Final[
 )
 @click.option("--fyre-user-name", required=True, help="Fyre API user name")
 @click.option("--fyre-api-key", required=True, help="Fyre API key")
+@loglevel_option()
 def ls(fyre_user_name: str, fyre_api_key: str):
     """List OpenShift clusters on FYRE"""
 

--- a/dg/commands/fyre/cluster/reboot.py
+++ b/dg/commands/fyre/cluster/reboot.py
@@ -24,6 +24,7 @@ import dg.lib.click
 import dg.utils.network
 
 from dg.lib.error import DataGateCLIException
+from dg.utils.logging import loglevel_option
 
 IBM_FYRE_REBOOT_CLUSTER_URL: Final[
     str
@@ -42,6 +43,7 @@ IBM_FYRE_REBOOT_CLUSTER_URL: Final[
 )
 @click.option("--fyre-user-name", required=True, help="Fyre API user name")
 @click.option("--fyre-api-key", required=True, help="Fyre API key")
+@loglevel_option()
 def reboot(cluster_name: str, fyre_user_name: str, fyre_api_key: str):
     """Reboot a cluster on FYRE"""
 

--- a/dg/commands/fyre/cluster/reboot.py
+++ b/dg/commands/fyre/cluster/reboot.py
@@ -24,14 +24,14 @@ import dg.lib.click
 import dg.utils.network
 
 from dg.lib.error import DataGateCLIException
-from dg.utils.logging import loglevel_option
+from dg.utils.logging import loglevel_command
 
 IBM_FYRE_REBOOT_CLUSTER_URL: Final[
     str
 ] = "https://api.fyre.ibm.com/rest/v1/?operation=reboot"
 
 
-@click.command(
+@loglevel_command(
     context_settings=dg.lib.click.create_default_map_from_json_file(
         dg.config.data_gate_configuration_manager.get_dg_credentials_file_path()
     )
@@ -43,7 +43,6 @@ IBM_FYRE_REBOOT_CLUSTER_URL: Final[
 )
 @click.option("--fyre-user-name", required=True, help="Fyre API user name")
 @click.option("--fyre-api-key", required=True, help="Fyre API key")
-@loglevel_option()
 def reboot(cluster_name: str, fyre_user_name: str, fyre_api_key: str):
     """Reboot a cluster on FYRE"""
 

--- a/dg/commands/fyre/cluster/rm.py
+++ b/dg/commands/fyre/cluster/rm.py
@@ -25,14 +25,14 @@ import dg.lib.click
 import dg.utils.network
 
 from dg.lib.error import DataGateCLIException
-from dg.utils.logging import loglevel_option
+from dg.utils.logging import loglevel_command
 
 IBM_FYRE_DELETE_CLUSTER_URL: Final[
     str
 ] = "https://api.fyre.ibm.com/rest/v1/?operation=delete"
 
 
-@click.command(
+@loglevel_command(
     context_settings=dg.lib.click.create_default_map_from_json_file(
         dg.config.data_gate_configuration_manager.get_dg_credentials_file_path()
     )
@@ -44,7 +44,6 @@ IBM_FYRE_DELETE_CLUSTER_URL: Final[
 )
 @click.option("--fyre-user-name", required=True, help="Fyre API user name")
 @click.option("--fyre-api-key", required=True, help="Fyre API key")
-@loglevel_option()
 def rm(cluster_name: str, fyre_user_name: str, fyre_api_key: str):
     """Delete a cluster on FYRE"""
 

--- a/dg/commands/fyre/cluster/rm.py
+++ b/dg/commands/fyre/cluster/rm.py
@@ -25,6 +25,7 @@ import dg.lib.click
 import dg.utils.network
 
 from dg.lib.error import DataGateCLIException
+from dg.utils.logging import loglevel_option
 
 IBM_FYRE_DELETE_CLUSTER_URL: Final[
     str
@@ -43,6 +44,7 @@ IBM_FYRE_DELETE_CLUSTER_URL: Final[
 )
 @click.option("--fyre-user-name", required=True, help="Fyre API user name")
 @click.option("--fyre-api-key", required=True, help="Fyre API key")
+@loglevel_option()
 def rm(cluster_name: str, fyre_user_name: str, fyre_api_key: str):
     """Delete a cluster on FYRE"""
 

--- a/dg/commands/fyre/login.py
+++ b/dg/commands/fyre/login.py
@@ -21,6 +21,7 @@ import dg.config
 import dg.utils.network
 
 from dg.lib.error import DataGateCLIException
+from dg.utils.logging import loglevel_option
 
 IBM_FYRE_SHOW_CLUSTERS_URL: Final[
     str
@@ -30,6 +31,7 @@ IBM_FYRE_SHOW_CLUSTERS_URL: Final[
 @click.command()
 @click.option("--fyre-api-key", required=True, help="FYRE API key")
 @click.option("--fyre-user-name", required=True, help="FYRE user name")
+@loglevel_option()
 def login(
     fyre_api_key: Union[str, None],
     fyre_user_name: Union[str, None],

--- a/dg/commands/fyre/login.py
+++ b/dg/commands/fyre/login.py
@@ -21,17 +21,16 @@ import dg.config
 import dg.utils.network
 
 from dg.lib.error import DataGateCLIException
-from dg.utils.logging import loglevel_option
+from dg.utils.logging import loglevel_command
 
 IBM_FYRE_SHOW_CLUSTERS_URL: Final[
     str
 ] = "https://api.fyre.ibm.com/rest/v1/?operation=query&request=showclusters"
 
 
-@click.command()
+@loglevel_command()
 @click.option("--fyre-api-key", required=True, help="FYRE API key")
 @click.option("--fyre-user-name", required=True, help="FYRE user name")
-@loglevel_option()
 def login(
     fyre_api_key: Union[str, None],
     fyre_user_name: Union[str, None],

--- a/dg/commands/fyre/logout.py
+++ b/dg/commands/fyre/logout.py
@@ -17,8 +17,11 @@ import click
 import dg.config
 import dg.lib.click
 
+from dg.utils.logging import loglevel_option
+
 
 @click.command()
+@loglevel_option()
 def logout():
     """Log out from FYRE"""
 

--- a/dg/commands/fyre/logout.py
+++ b/dg/commands/fyre/logout.py
@@ -12,16 +12,13 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import click
-
 import dg.config
 import dg.lib.click
 
-from dg.utils.logging import loglevel_option
+from dg.utils.logging import loglevel_command
 
 
-@click.command()
-@loglevel_option()
+@loglevel_command()
 def logout():
     """Log out from FYRE"""
 

--- a/dg/commands/ibmcloud/cluster/add.py
+++ b/dg/commands/ibmcloud/cluster/add.py
@@ -18,10 +18,10 @@ import dg.config.cluster_credentials_manager
 import dg.lib.ibmcloud.cluster
 import dg.lib.ibmcloud.status
 
-from dg.utils.logging import loglevel_option
+from dg.utils.logging import loglevel_command
 
 
-@click.command()
+@loglevel_command()
 @click.option(
     "--alias", help="Alias used to reference a cluster instead of its server URL"
 )
@@ -30,7 +30,6 @@ from dg.utils.logging import loglevel_option
     required=True,
     help="Name of the OpenShift cluster to be registered",
 )
-@loglevel_option()
 def add(alias: str, cluster_name: str):
     """Register an existing OpenShift cluster on IBM Cloud"""
 

--- a/dg/commands/ibmcloud/cluster/add.py
+++ b/dg/commands/ibmcloud/cluster/add.py
@@ -18,6 +18,8 @@ import dg.config.cluster_credentials_manager
 import dg.lib.ibmcloud.cluster
 import dg.lib.ibmcloud.status
 
+from dg.utils.logging import loglevel_option
+
 
 @click.command()
 @click.option(
@@ -28,6 +30,7 @@ import dg.lib.ibmcloud.status
     required=True,
     help="Name of the OpenShift cluster to be registered",
 )
+@loglevel_option()
 def add(alias: str, cluster_name: str):
     """Register an existing OpenShift cluster on IBM Cloud"""
 

--- a/dg/commands/ibmcloud/cluster/create.py
+++ b/dg/commands/ibmcloud/cluster/create.py
@@ -12,6 +12,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import logging
+
 import click
 
 from dg.lib.error import IBMCloudException
@@ -30,6 +32,9 @@ from dg.lib.ibmcloud.vlan import (
     get_default_private_vlan,
     get_default_public_vlan,
 )
+from dg.utils.logging import loglevel_option
+
+logger = logging.getLogger(__name__)
 
 
 @click.command()
@@ -57,6 +62,7 @@ from dg.lib.ibmcloud.vlan import (
     help="Remove any prompts during cluster creation.",
     is_flag=True,
 )
+@loglevel_option()
 def create(
     cluster_name: str, full_installation: bool, remove_existing: bool, force: bool
 ):
@@ -66,21 +72,26 @@ def create(
         login_to_ibm_cloud()
 
     if remove_existing:
-        click.secho(
-            f"Deleting existing cluster '{cluster_name}'.", fg="bright_white", bold=True
+        logger.info(
+            click.style(
+                f"Deleting existing cluster '{cluster_name}'.",
+                bold=True,
+            )
         )
+
         if cluster_exists(cluster_name):
             delete_ibmcloud_cluster(cluster_name, force)
             wait_for_cluster_deletion(cluster_name)
         else:
-            click.echo(
+            logging.info(
                 f"Skipping deletion, as cluster '{cluster_name}' could not be found."
             )
 
-    click.secho(
-        f"Creating OpenShift cluster with name '{cluster_name}' in IBM Cloud.",
-        fg="bright_white",
-        bold=True,
+    logging.info(
+        click.style(
+            f"Creating OpenShift cluster with name '{cluster_name}' in IBM Cloud.",
+            bold=True,
+        )
     )
 
     openshift_version = get_latest_supported_openshift_version()
@@ -113,9 +124,7 @@ def create(
         "--zone",
         zone,
     ]
-    click.echo(
-        "Executing cluster creation command 'ibmcloud " + " ".join(command) + "'"
-    )
+
     result = execute_ibmcloud_command_without_check(command, capture_output=True)
 
     if result.return_code != 0:
@@ -126,7 +135,7 @@ def create(
             if cluster_exists(cluster_name):
                 # There was an error, but the cluster was created nonetheless, print a warning
 
-                click.echo(
+                logging.warning(
                     f"Warning: An error occurred while creating the cluster, but 'ibmcloud oc cluster ls' shows a "
                     f"cluster with the name '{cluster_name}' – error details:\n"
                     f"{IBMCloudException.get_parsed_error_message(result.stderr)}"
@@ -137,13 +146,14 @@ def create(
         click.echo(result.stdout)
 
     if full_installation:
-
-        click.echo(f"Waiting for creation of cluster '{cluster_name}' to complete.")
+        logging.info(f"Waiting for creation of cluster '{cluster_name}' to complete.")
         wait_for_cluster_readiness(cluster_name)
 
-        click.secho(
-            f"Installing Cloud Pak for Data on cluster '{cluster_name}'.",
-            fg="bright_white",
-            bold=True,
+        logging.info(
+            click.style(
+                f"Installing Cloud Pak for Data on cluster '{cluster_name}'.",
+                bold=True,
+            )
         )
+
         install_cp4d_with_preinstall(cluster_name)

--- a/dg/commands/ibmcloud/cluster/create.py
+++ b/dg/commands/ibmcloud/cluster/create.py
@@ -32,12 +32,12 @@ from dg.lib.ibmcloud.vlan import (
     get_default_private_vlan,
     get_default_public_vlan,
 )
-from dg.utils.logging import loglevel_option
+from dg.utils.logging import loglevel_command
 
 logger = logging.getLogger(__name__)
 
 
-@click.command()
+@loglevel_command()
 @click.option("-c", "--cluster-name", required=True, help="cluster name")
 @click.option(
     "-i",
@@ -62,7 +62,6 @@ logger = logging.getLogger(__name__)
     help="Remove any prompts during cluster creation.",
     is_flag=True,
 )
-@loglevel_option()
 def create(
     cluster_name: str, full_installation: bool, remove_existing: bool, force: bool
 ):
@@ -136,8 +135,8 @@ def create(
                 # There was an error, but the cluster was created nonetheless, print a warning
 
                 logging.warning(
-                    f"Warning: An error occurred while creating the cluster, but 'ibmcloud oc cluster ls' shows a "
-                    f"cluster with the name '{cluster_name}' – error details:\n"
+                    f"An error occurred while creating the cluster, but 'ibmcloud oc cluster ls' shows a cluster with "
+                    f"the name '{cluster_name}' – error details:\n"
                     f"{IBMCloudException.get_parsed_error_message(result.stderr)}"
                 )
             else:

--- a/dg/commands/ibmcloud/cluster/increase_ir_volume_capacity.py
+++ b/dg/commands/ibmcloud/cluster/increase_ir_volume_capacity.py
@@ -19,14 +19,13 @@ import click
 import dg.commands.ibmcloud.cluster.login
 import dg.lib.ibmcloud.volume
 
-from dg.utils.logging import loglevel_option
+from dg.utils.logging import loglevel_command
 
 REQUIRED_OPENSHIFT_IMAGE_REGISTRY_VOLUME_CAPACITY_IN_GB: Final[int] = 200
 
 
-@click.command()
+@loglevel_command()
 @click.option("--name", required=True, help="cluster name")
-@loglevel_option()
 def increase_ir_volume_capacity(name: str):
     """Increase capacity of volume in openshift-image-registry namespace"""
 

--- a/dg/commands/ibmcloud/cluster/increase_ir_volume_capacity.py
+++ b/dg/commands/ibmcloud/cluster/increase_ir_volume_capacity.py
@@ -19,11 +19,14 @@ import click
 import dg.commands.ibmcloud.cluster.login
 import dg.lib.ibmcloud.volume
 
+from dg.utils.logging import loglevel_option
+
 REQUIRED_OPENSHIFT_IMAGE_REGISTRY_VOLUME_CAPACITY_IN_GB: Final[int] = 200
 
 
 @click.command()
 @click.option("--name", required=True, help="cluster name")
+@loglevel_option()
 def increase_ir_volume_capacity(name: str):
     """Increase capacity of volume in openshift-image-registry namespace"""
 

--- a/dg/commands/ibmcloud/cluster/install.py
+++ b/dg/commands/ibmcloud/cluster/install.py
@@ -15,12 +15,11 @@
 import click
 
 from dg.lib.ibmcloud.install import install_cp4d_with_preinstall
-from dg.utils.logging import loglevel_option
+from dg.utils.logging import loglevel_command
 
 
-@click.command()
+@loglevel_command()
 @click.option("-c", "--cluster-name", required=True, help="cluster name")
-@loglevel_option()
 def install(cluster_name: str):
     """Install Cloud Pak for Data, including Db2 Warehouse and Db2 Data Gate, on the given IBM Cloud cluster"""
 

--- a/dg/commands/ibmcloud/cluster/install.py
+++ b/dg/commands/ibmcloud/cluster/install.py
@@ -15,10 +15,12 @@
 import click
 
 from dg.lib.ibmcloud.install import install_cp4d_with_preinstall
+from dg.utils.logging import loglevel_option
 
 
 @click.command()
 @click.option("-c", "--cluster-name", required=True, help="cluster name")
+@loglevel_option()
 def install(cluster_name: str):
     """Install Cloud Pak for Data, including Db2 Warehouse and Db2 Data Gate, on the given IBM Cloud cluster"""
 

--- a/dg/commands/ibmcloud/cluster/login.py
+++ b/dg/commands/ibmcloud/cluster/login.py
@@ -20,12 +20,11 @@ from dg.lib.error import DataGateCLIException
 from dg.lib.ibmcloud.cluster.ibmcloud_cluster_factory import (
     ibm_cloud_cluster_factory,
 )
-from dg.utils.logging import loglevel_option
+from dg.utils.logging import loglevel_command
 
 
-@click.command()
+@loglevel_command()
 @click.option("--cluster-name", required=True, help="cluster name")
-@loglevel_option()
 def login(cluster_name: str):
     """Log in to an OpenShift cluster"""
 

--- a/dg/commands/ibmcloud/cluster/login.py
+++ b/dg/commands/ibmcloud/cluster/login.py
@@ -20,10 +20,12 @@ from dg.lib.error import DataGateCLIException
 from dg.lib.ibmcloud.cluster.ibmcloud_cluster_factory import (
     ibm_cloud_cluster_factory,
 )
+from dg.utils.logging import loglevel_option
 
 
 @click.command()
 @click.option("--cluster-name", required=True, help="cluster name")
+@loglevel_option()
 def login(cluster_name: str):
     """Log in to an OpenShift cluster"""
 

--- a/dg/commands/ibmcloud/cluster/ls.py
+++ b/dg/commands/ibmcloud/cluster/ls.py
@@ -15,6 +15,7 @@
 import click
 
 from dg.lib.ibmcloud.cluster.ls import list_existing_clusters
+from dg.utils.logging import loglevel_option
 
 
 @click.command()
@@ -24,6 +25,7 @@ from dg.lib.ibmcloud.cluster.ls import list_existing_clusters
     help="Prints the command output in JSON format.",
     is_flag=True,
 )
+@loglevel_option("WARNING")
 def ls(json: bool):
     """List all available clusters"""
 

--- a/dg/commands/ibmcloud/cluster/ls.py
+++ b/dg/commands/ibmcloud/cluster/ls.py
@@ -15,17 +15,16 @@
 import click
 
 from dg.lib.ibmcloud.cluster.ls import list_existing_clusters
-from dg.utils.logging import loglevel_option
+from dg.utils.logging import loglevel_command
 
 
-@click.command()
+@loglevel_command(default_log_level="WARNING")
 @click.option(
     "--json",
     required=False,
     help="Prints the command output in JSON format.",
     is_flag=True,
 )
-@loglevel_option("WARNING")
 def ls(json: bool):
     """List all available clusters"""
 

--- a/dg/commands/ibmcloud/cluster/rm.py
+++ b/dg/commands/ibmcloud/cluster/rm.py
@@ -15,6 +15,7 @@
 import click
 
 from dg.lib.ibmcloud.cluster.rm import delete_ibmcloud_cluster
+from dg.utils.logging import loglevel_option
 
 
 @click.command()
@@ -26,6 +27,7 @@ from dg.lib.ibmcloud.cluster.rm import delete_ibmcloud_cluster
     help="Force deletion of the cluster",
     is_flag=True,
 )
+@loglevel_option()
 def rm(cluster_name: str, force_deletion: bool):
     """Delete an existing OpenShift cluster on IBM Cloud"""
 

--- a/dg/commands/ibmcloud/cluster/rm.py
+++ b/dg/commands/ibmcloud/cluster/rm.py
@@ -15,10 +15,10 @@
 import click
 
 from dg.lib.ibmcloud.cluster.rm import delete_ibmcloud_cluster
-from dg.utils.logging import loglevel_option
+from dg.utils.logging import loglevel_command
 
 
-@click.command()
+@loglevel_command()
 @click.option("-c", "--cluster-name", required=True, help="cluster name")
 @click.option(
     "--force",
@@ -27,7 +27,6 @@ from dg.utils.logging import loglevel_option
     help="Force deletion of the cluster",
     is_flag=True,
 )
-@loglevel_option()
 def rm(cluster_name: str, force_deletion: bool):
     """Delete an existing OpenShift cluster on IBM Cloud"""
 

--- a/dg/commands/ibmcloud/cluster/status.py
+++ b/dg/commands/ibmcloud/cluster/status.py
@@ -16,6 +16,8 @@ import click
 
 import dg.lib.ibmcloud.status
 
+from dg.utils.logging import loglevel_option
+
 
 @click.command()
 @click.option("--cluster-name", required=True, help="cluster name")
@@ -25,6 +27,7 @@ import dg.lib.ibmcloud.status
     help="Prints the command output in JSON format.",
     is_flag=True,
 )
+@loglevel_option("WARNING")
 def status(cluster_name: str, json: bool):
     """Display the status of a given cluster"""
 

--- a/dg/commands/ibmcloud/cluster/status.py
+++ b/dg/commands/ibmcloud/cluster/status.py
@@ -16,10 +16,10 @@ import click
 
 import dg.lib.ibmcloud.status
 
-from dg.utils.logging import loglevel_option
+from dg.utils.logging import loglevel_command
 
 
-@click.command()
+@loglevel_command(default_log_level="WARNING")
 @click.option("--cluster-name", required=True, help="cluster name")
 @click.option(
     "--json",
@@ -27,7 +27,6 @@ from dg.utils.logging import loglevel_option
     help="Prints the command output in JSON format.",
     is_flag=True,
 )
-@loglevel_option("WARNING")
 def status(cluster_name: str, json: bool):
     """Display the status of a given cluster"""
 

--- a/dg/commands/ibmcloud/generate_api_key.py
+++ b/dg/commands/ibmcloud/generate_api_key.py
@@ -25,10 +25,10 @@ from dg.lib.ibmcloud import (
     INTERNAL_IBM_CLOUD_API_KEY_NAME,
 )
 from dg.lib.ibmcloud.iam import api_key_exists, delete_api_key_in_ibmcloud
-from dg.utils.logging import loglevel_option
+from dg.utils.logging import loglevel_command
 
 
-@click.command()
+@loglevel_command()
 @click.option(
     "--delete-existing-api-key",
     required=False,
@@ -37,7 +37,6 @@ from dg.utils.logging import loglevel_option
     ),
     is_flag=True,
 )
-@loglevel_option()
 def generate_api_key(delete_existing_api_key: bool) -> str:
     """Generates an IBM Cloud API key and stores it in the Data Gate CLI
     credentials file"""

--- a/dg/commands/ibmcloud/generate_api_key.py
+++ b/dg/commands/ibmcloud/generate_api_key.py
@@ -25,6 +25,7 @@ from dg.lib.ibmcloud import (
     INTERNAL_IBM_CLOUD_API_KEY_NAME,
 )
 from dg.lib.ibmcloud.iam import api_key_exists, delete_api_key_in_ibmcloud
+from dg.utils.logging import loglevel_option
 
 
 @click.command()
@@ -36,6 +37,7 @@ from dg.lib.ibmcloud.iam import api_key_exists, delete_api_key_in_ibmcloud
     ),
     is_flag=True,
 )
+@loglevel_option()
 def generate_api_key(delete_existing_api_key: bool) -> str:
     """Generates an IBM Cloud API key and stores it in the Data Gate CLI
     credentials file"""

--- a/dg/commands/ibmcloud/login.py
+++ b/dg/commands/ibmcloud/login.py
@@ -12,14 +12,11 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import click
-
 from dg.lib.ibmcloud.login import login as login_to_ibm_cloud
-from dg.utils.logging import loglevel_option
+from dg.utils.logging import loglevel_command
 
 
-@click.command()
-@loglevel_option()
+@loglevel_command()
 def login():
     """Log in to IBM Cloud"""
 

--- a/dg/commands/ibmcloud/login.py
+++ b/dg/commands/ibmcloud/login.py
@@ -15,9 +15,11 @@
 import click
 
 from dg.lib.ibmcloud.login import login as login_to_ibm_cloud
+from dg.utils.logging import loglevel_option
 
 
 @click.command()
+@loglevel_option()
 def login():
     """Log in to IBM Cloud"""
 

--- a/dg/commands/ibmcloud/logout.py
+++ b/dg/commands/ibmcloud/logout.py
@@ -12,6 +12,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import logging
+
 from subprocess import CalledProcessError
 
 import click
@@ -25,6 +27,9 @@ from dg.lib.ibmcloud import (
 )
 from dg.lib.ibmcloud.iam import delete_api_key_in_ibmcloud
 from dg.lib.ibmcloud.login import is_logged_in
+from dg.utils.logging import loglevel_option
+
+logger = logging.getLogger(__name__)
 
 
 @click.command()
@@ -34,11 +39,13 @@ from dg.lib.ibmcloud.login import is_logged_in
     help="Delete the API key which was created for the Data Gate CLI (in IBM Cloud and on disk)",
     is_flag=True,
 )
+@loglevel_option()
 def logout(delete_api_key: bool):
     """Log out from IBM Cloud"""
 
     if delete_api_key:
-        click.echo("Deleting the Data Gate API key in IBM Cloud")
+        logger.info("Deleting the Data Gate API key in IBM Cloud")
+
         try:
             delete_api_key_in_ibmcloud()
         except CalledProcessError as error:
@@ -51,15 +58,14 @@ def logout(delete_api_key: bool):
                     f"delete them using '{str(data_gate_configuration_manager.get_ibmcloud_cli_path())} iam "
                     f"api-key-delete {EXTERNAL_IBM_CLOUD_API_KEY_NAME}'"
                 )
-        click.echo("Deleting the Data Gate API key on disk")
+
+        logger.info("Deleting the Data Gate API key on disk")
         data_gate_configuration_manager.store_credentials(
             {INTERNAL_IBM_CLOUD_API_KEY_NAME: ""}
         )
 
     if is_logged_in():
         _perform_logout()
-    else:
-        click.echo("Not logged in, no need to logout")
 
 
 def _perform_logout():

--- a/dg/commands/ibmcloud/logout.py
+++ b/dg/commands/ibmcloud/logout.py
@@ -27,19 +27,18 @@ from dg.lib.ibmcloud import (
 )
 from dg.lib.ibmcloud.iam import delete_api_key_in_ibmcloud
 from dg.lib.ibmcloud.login import is_logged_in
-from dg.utils.logging import loglevel_option
+from dg.utils.logging import loglevel_command
 
 logger = logging.getLogger(__name__)
 
 
-@click.command()
+@loglevel_command()
 @click.option(
     "--delete-api-key",
     required=False,
     help="Delete the API key which was created for the Data Gate CLI (in IBM Cloud and on disk)",
     is_flag=True,
 )
-@loglevel_option()
 def logout(delete_api_key: bool):
     """Log out from IBM Cloud"""
 

--- a/dg/commands/ibmcloud/nuclear/nuke_storage.py
+++ b/dg/commands/ibmcloud/nuclear/nuke_storage.py
@@ -19,16 +19,15 @@ from subprocess import CalledProcessError
 import click
 
 from dg.lib.ibmcloud import execute_ibmcloud_command
-from dg.utils.logging import loglevel_option
+from dg.utils.logging import loglevel_command
 
 logger = logging.getLogger(__name__)
 
 
-@click.command()
+@loglevel_command()
 @click.option(
     "--zone", required=True, help="Zone to delete deployments in (e.g. sjc03)"
 )
-@loglevel_option()
 def nuke_storage(zone: str):
     """Immediately cancel ALL classic file storage volumes on IBM Cloud in a given zone"""
 

--- a/dg/dg.py
+++ b/dg/dg.py
@@ -12,7 +12,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import logging
 import sys
 
 import click
@@ -20,13 +19,9 @@ import pkg_resources
 
 import dg.commands
 import dg.utils.debugger
+import dg.utils.logging
 
-logging.basicConfig(
-    datefmt="%Y-%m-%dT%H:%M:%S%z",
-    format="%(asctime)s [%(levelname)s]: %(message)s",
-    level=logging.WARNING,
-)
-
+dg.utils.logging.init_root_logger()
 
 if dg.utils.debugger.is_debugpy_running() and (len(sys.argv) == 2):
     if sys.argv[1] == "":

--- a/dg/lib/ibmcloud/cluster/rm.py
+++ b/dg/lib/ibmcloud/cluster/rm.py
@@ -25,8 +25,6 @@ def delete_ibmcloud_cluster(name: str, force_deletion: bool):
     """Delete an existing OpenShift cluster on IBM Cloud"""
 
     command = ["oc", "cluster", "rm", "--cluster", name]
-    click.echo("Executing cluster remove command 'ibmcloud " + " ".join(command) + "'")
-
     return_code = 0
 
     if force_deletion:

--- a/dg/lib/ibmcloud/install.py
+++ b/dg/lib/ibmcloud/install.py
@@ -12,6 +12,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import logging
+
 import json
 
 from time import sleep
@@ -34,6 +36,8 @@ from dg.lib.ibmcloud.iam import get_oauth_token, get_tokens
 from dg.lib.ibmcloud.login import is_logged_in
 from dg.lib.ibmcloud.target import get_ibmcloud_account_target_information
 from dg.utils.wait import wait_for
+
+logger = logging.getLogger(__name__)
 
 
 def _get_cp4d_version_locator(cp4d_version: str) -> str:
@@ -169,7 +173,7 @@ def execute_install(cluster_id: str, api_key: str) -> Any:
     response = requests.post(url, headers=headers, json=data)
 
     if response.ok:
-        click.echo("Installation request submitted successfully.")
+        logging.info("Installation request submitted successfully.")
     else:
         raise DataGateCLIException(
             f"Failed to start Cloud Pak for Data installation on cluster {cluster_id}:\n"
@@ -364,21 +368,21 @@ def install_cp4d_with_preinstall(cluster_name: str):
             f"login' to log in."
         )
 
-    click.echo(
+    logging.info(
         f"Executing Cloud Pak for Data pre-installation on cluster {cluster_name}"
     )
 
     execute_preinstall(cluster_name)
 
     # TODO Use proper endpoint to obtain preinstall status (Current function in ibmcloud CLI is not working)
-    click.echo(f"Waiting for preinstallation on cluster {cluster_name} to finish:")
+    logging.info(f"Waiting for preinstallation on cluster {cluster_name} to finish:")
     wait_until_preinstallation_is_finished(1, 300)
 
-    click.echo(f"Executing Cloud Pak for Data installation on cluster {cluster_name}")
+    logging.info(f"Executing Cloud Pak for Data installation on cluster {cluster_name}")
     install_details = execute_install(cluster_name, api_key)
 
-    click.echo(f"Waiting for installation on cluster {cluster_name} to finish:")
+    logging.info(f"Waiting for installation on cluster {cluster_name} to finish:")
     wait_until_installation_is_finished(install_details)
 
     url = get_cp4d_url(install_details)
-    click.echo(f"Cloud Pak for Data URL: {url}")
+    logging.info(f"Cloud Pak for Data URL: {url}")

--- a/dg/lib/ibmcloud/plugin.py
+++ b/dg/lib/ibmcloud/plugin.py
@@ -1,7 +1,9 @@
-import click
+import logging
 
 from dg.lib.error import IBMCloudException
 from dg.lib.ibmcloud import execute_ibmcloud_command_without_check
+
+logger = logging.getLogger(__name__)
 
 
 def install_catalogs_management_plugin():
@@ -21,7 +23,7 @@ def is_container_service_plugin_installed() -> bool:
 
 
 def _install_plugin(plugin_name: str):
-    click.echo(f"Installing IBM Cloud plug-in '{plugin_name}'")
+    logging.info(f"Installing IBM Cloud plug-in '{plugin_name}'")
 
     args = ["plugin", "install", plugin_name]
     result = execute_ibmcloud_command_without_check(args, capture_output=True)

--- a/dg/lib/ibmcloud/vlan.py
+++ b/dg/lib/ibmcloud/vlan.py
@@ -1,9 +1,10 @@
 import json
-
-import click
+import logging
 
 from dg.lib.error import DataGateCLIException
 from dg.lib.ibmcloud import execute_ibmcloud_command
+
+logger = logging.getLogger(__name__)
 
 
 def get_default_public_vlan(zone: str) -> str:
@@ -32,7 +33,7 @@ def _get_default_vlan_id(vlan_type: str, zone: str) -> str:
                 break
 
     if not vlan_id:
-        click.echo("Returned VLAN information:" + result.stdout)
+        logging.info("Returned VLAN information:" + result.stdout)
 
         raise DataGateCLIException(
             f"Could not obtain default {vlan_type} VLAN ID for zone {zone}."

--- a/dg/utils/download.py
+++ b/dg/utils/download.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 
 import io
+import logging
 import os
 import pathlib
 import re as regex
@@ -21,10 +22,11 @@ import urllib.parse
 
 from typing import Any
 
-import click
 import requests
 
 from tqdm import tqdm
+
+logger = logging.getLogger(__name__)
 
 
 def download_file(url: urllib.parse.SplitResult, **kwargs: Any) -> pathlib.Path:
@@ -77,7 +79,7 @@ def download_file(url: urllib.parse.SplitResult, **kwargs: Any) -> pathlib.Path:
     else:
         file_name = os.path.basename(urllib.parse.urlsplit(response.url).path)
 
-    click.echo("Downloading: {} [{}]".format(response.url, file_name))
+    logger.info("Downloading: {} [{}]".format(response.url, file_name))
 
     content_length = (
         int(str(response.headers.get("Content-Length")))
@@ -139,7 +141,7 @@ def download_file_into_buffer(
         file_name = os.path.basename(urllib.parse.urlsplit(response.url).path)
 
     if ("silent" not in kwargs) or not kwargs["silent"]:
-        click.echo("Downloading: {} [{}]".format(response.url, file_name))
+        logger.info("Downloading: {} [{}]".format(response.url, file_name))
 
     content_length = (
         int(str(response.headers.get("Content-Length")))

--- a/dg/utils/logging.py
+++ b/dg/utils/logging.py
@@ -1,0 +1,118 @@
+import logging
+from typing import Callable
+
+import click
+
+
+class ClickLoggingFormatter(logging.Formatter):
+    """Click-based log formatter
+
+    Instances of this formatter create colored log messages using the
+    following format:
+
+    YYYY-MM-DDThh:mm:ss±hhmm ["   DEBUG"|
+                              "    INFO"|
+                              " WARNING"|
+                              "   ERROR"|
+                              "CRITICAL"]: {message}
+    """
+
+    def __init__(self):
+        super().__init__(
+            datefmt="%Y-%m-%dT%H:%M:%S%z",
+            fmt="%(asctime)s [%(levelname)8s]: %(message)s",
+        )
+
+    def format(self, record: logging.LogRecord) -> str:
+        """Formats the given log record
+
+        Parameters
+        ----------
+        record
+            log record
+
+        Returns
+        -------
+        str
+            formatted log record message
+        """
+
+        colors = {
+            "CRITICAL": dict(fg="magenta"),
+            "DEBUG": dict(fg="blue"),
+            "ERROR": dict(fg="red"),
+            "WARNING": dict(fg="yellow"),
+        }
+
+        return (
+            click.style(
+                logging.Formatter.format(self, record), **colors[record.levelname]
+            )
+            if record.levelname in colors
+            else logging.Formatter.format(self, record)
+        )
+
+
+class ClickLoggingHandler(logging.Handler):
+    """Click-based log handler"""
+
+    def emit(self, record: logging.LogRecord):
+        """Prints the given log record using click.echo()
+
+        Parameters
+        ----------
+        record
+            log record
+        """
+
+        click.echo(self.format(record))
+
+
+class ScopedLoggingDisabler:
+    """Temprarily disables logging when used as part of a with statement"""
+
+    def __init__(self, is_enabled=True) -> None:
+        self._is_enabled = is_enabled
+        self._previous_value = False
+
+    def __enter__(self):
+        if self._is_enabled:
+            logging.getLogger().disabled = self._previous_value
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        if self._is_enabled:
+            self._previous_value = logging.getLogger().disabled
+            logging.getLogger().disabled = False
+
+
+def init_root_logger():
+    """Initializes the root logger to use an instance of
+    ClickLoggingFormatter as a formatter and an instance of
+    ClickLoggingHandler as a handler"""
+
+    click_logging_handler = ClickLoggingHandler()
+    click_logging_handler.formatter = ClickLoggingFormatter()
+
+    logging.getLogger().handlers = [click_logging_handler]
+
+
+def loglevel_option(default="INFO") -> Callable:
+    """Decorator adding a --loglevel option to a Click command
+
+    Parameters
+    ----------
+    default
+        default log level
+    """
+
+    return click.option(
+        "--loglevel",
+        callback=lambda ctx, param, value: logging.getLogger().setLevel(value),
+        default=default,
+        expose_value=False,
+        help="Log level",
+        is_eager=True,
+        type=click.Choice(
+            ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"], case_sensitive=False
+        ),
+    )


### PR DESCRIPTION
This pull request introduces a unified approach for console output.

## Coding Guidelines Suggestions	

There are two methods to display output on the console:

- using `click.echo()` [`print()` [should not be used](https://click.palletsprojects.com/en/7.x/utils/#printing-to-stdout)]
- using the `logging` package

This pull request configures the root logger of the `logging` package to prefix each message of a log record with the current timestamp and the log level of the log record using colored output:

<img width="578" alt="data_gate_cli_screenshot_1" src="https://user-images.githubusercontent.com/22716545/107745993-6f101d80-6d15-11eb-9f23-baaad5162151.png">

<img width="578" alt="data_gate_cli_screenshot_2" src="https://user-images.githubusercontent.com/22716545/107750307-2314a700-6d1c-11eb-87d6-4d6d95a57ae2.png">

Therefore, I suggest the following decision criterion when to use which method:

- Use `click.echo()` when printing the current timestamp and the log level is not appropriate. For example, when …

  - … printing formatted output:

    ```
    dg cluster ls
    ```

  - … printing output important for subsequent user interaction:

    ```python
    click.style(
        f"Do you really wish to immediately cancel all classic file storage volumes in zone '{zone}'?",
        bold=True,
        fg="red",
    )
    ```

  - … printing output that may be consumed by other programs:

    ```
    dg cluster current
    ```

- Use `logging.debug()` when printing debug messages.

- Use `logging.info()` when printing informational messages, which are shown by default, and printing the current timestamp and the log level is appropriate. For example, when printing information about a subsequently executed longer-running command:

  ```python
  logging.info(f"Waiting for creation of cluster '{cluster_name}' to complete.")
  ```

- Use `logging.warning()` when printing a warning and printing the current timestamp and the log level is appropriate:

  ```python
  logging.warning(
      f"Warning: An error occurred while creating the cluster, but 'ibmcloud oc cluster ls' shows a "
      f"cluster with the name '{cluster_name}' – error details:\n"
      f"{IBMCloudException.get_parsed_error_message(result.stderr)}"
  )
  ```

Instead of using `logging.error()` or `logging.critical()`, raising an exception is probably more appropriate in most cases.

I replaced some occurrences of `click.echo()` in the codebase with `logging.info()` or `logging.warning()` according to these suggestions. Please comment if you disagree with any replacements.

## Click Support

The advantage of the `logging` package is that the log level of the current logger may be changed to suppress log messages. To expose this feature when executing commands of the Data Gate CLI, this pull request adds a decorator named `@loglevel_option()`. When adding this decorator to a Click command, a non-required option named `--loglevel` is automatically added to the Click command:

```
Options:
[…]
  --loglevel [DEBUG|INFO|WARNING|ERROR|CRITICAL]
                                  Log level
  --help                          Show this message and exit.
```

The default log level set by this option is `INFO`.

The `logging` package and the decorator may be used as follows:

```python
import logging

from dg.utils.logging import loglevel_option

logger = logging.getLogger(__name__)


@click.command()
@loglevel_option()
def command():
    logger.info("…")
```

In some cases, it makes sense to set the default log level to WARNING. For example, when a command displays output that may be consumed by other programs, but it invokes code that uses the `logging` package and displays undesired log messages. In this case, the default log level may be passed to the decorator:

```python
@loglevel_option("WARNING")
```

## Colored Output

When using the `logging` package, output may be styled as follows:

```python
logging.info(click.style("[…]", […]))
```

I would suggest to not use `fg="bright_white"` or `fg="white"` as white output is invisible when using a shell theme with a light background. Therefore, I removed all occurrences in the codebase.