### PR TITLE
Support lazy loading of Click commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,19 +118,14 @@ To register a new Click command, add the Python module containing the command to
 To register a new Click group, add a Python package (i.e., a directory containing a file named `__init__.py`) to the `commands` directory or one of its subdirectories. Furthermore, add the following code to `__init__.py` to automatically register Click commands within Python modules contained in the package:
 
 ```python
+import sys
+
 import click
-import pathlib
 
-import dg.lib.click as dgclick
-
-
-def get_click_multi_command_class() -> type[click.Command]:
-    return dgclick.create_click_multi_command_class(
-        dgclick.import_packages_and_modules(__name__, pathlib.Path(__file__).parent)
-    )
+from dg.lib.click.lazy_loading_multi_command import create_click_multi_command_class
 
 
-@click.command(cls=get_click_multi_command_class())
+@click.command(cls=create_click_multi_command_class(sys.modules[__name__]))
 def {Click group name}():
     pass
 ```

--- a/dg/commands/adm/__init__.py
+++ b/dg/commands/adm/__init__.py
@@ -12,20 +12,14 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import pathlib
+import sys
 
 import click
 
-import dg.lib.click as dgclick
+from dg.lib.click.lazy_loading_multi_command import create_click_multi_command_class
 
 
-def get_click_multi_command_class() -> type[click.Command]:
-    return dgclick.create_click_multi_command_class(
-        dgclick.import_packages_and_modules(__name__, pathlib.Path(__file__).parent)
-    )
-
-
-@click.command(cls=get_click_multi_command_class())
+@click.command(cls=create_click_multi_command_class(sys.modules[__name__]))
 def adm():
     """Data Gate CLI administration commands"""
 

--- a/dg/commands/adm/config/__init__.py
+++ b/dg/commands/adm/config/__init__.py
@@ -12,21 +12,15 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import pathlib
+import sys
 
 import click
 
-import dg.lib.click as dgclick
+from dg.lib.click.lazy_loading_multi_command import create_click_multi_command_class
 
 
-def get_click_multi_command_class() -> type[click.Command]:
-    return dgclick.create_click_multi_command_class(
-        dgclick.import_packages_and_modules(__name__, pathlib.Path(__file__).parent)
-    )
-
-
-@click.command(cls=get_click_multi_command_class())
+@click.command(cls=create_click_multi_command_class(sys.modules[__name__]))
 def config():
-    """Modify the dg configuration"""
+    """Modify the Data Gate CLI configuration"""
 
     pass

--- a/dg/commands/cluster/__init__.py
+++ b/dg/commands/cluster/__init__.py
@@ -12,20 +12,14 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import pathlib
+import sys
 
 import click
 
-import dg.lib.click as dgclick
+from dg.lib.click.lazy_loading_multi_command import create_click_multi_command_class
 
 
-def get_click_multi_command_class() -> type[click.Command]:
-    return dgclick.create_click_multi_command_class(
-        dgclick.import_packages_and_modules(__name__, pathlib.Path(__file__).parent)
-    )
-
-
-@click.command(cls=get_click_multi_command_class())
+@click.command(cls=create_click_multi_command_class(sys.modules[__name__]))
 def cluster():
     """Cluster context commands"""
 

--- a/dg/commands/cluster/install_assembly.py
+++ b/dg/commands/cluster/install_assembly.py
@@ -20,7 +20,7 @@ import semver
 from click_option_group import optgroup
 
 import dg.config.cluster_credentials_manager
-import dg.lib.click
+import dg.lib.click.utils
 import dg.lib.openshift
 import dg.utils.download
 
@@ -35,7 +35,7 @@ from dg.utils.logging import loglevel_command
 
 
 @loglevel_command(
-    context_settings=dg.lib.click.create_default_map_from_dict(
+    context_settings=dg.lib.click.utils.create_default_map_from_dict(
         dg.config.cluster_credentials_manager.cluster_credentials_manager.get_current_credentials()
     )
 )
@@ -91,8 +91,8 @@ def install_assembly(
 
     cloud_pak_for_data_assembly_build_type = CloudPakForDataAssemblyBuildType[build_type.upper()]
 
-    dg.lib.click.check_cloud_pak_for_data_options(ctx, cloud_pak_for_data_assembly_build_type, locals().copy())
-    dg.lib.click.log_in_to_openshift_cluster(ctx, locals().copy())
+    dg.lib.click.utils.check_cloud_pak_for_data_options(ctx, cloud_pak_for_data_assembly_build_type, locals().copy())
+    dg.lib.click.utils.log_in_to_openshift_cluster(ctx, locals().copy())
 
     cloud_pak_for_data_manager = CloudPakForDataManagerFactory.get_cloud_pak_for_data_manager(
         semver.VersionInfo.parse(version)

--- a/dg/commands/cluster/install_cloud_pak_for_data.py
+++ b/dg/commands/cluster/install_cloud_pak_for_data.py
@@ -21,7 +21,7 @@ from click_option_group import optgroup
 
 import dg.config
 import dg.config.cluster_credentials_manager
-import dg.lib.click
+import dg.lib.click.utils
 import dg.lib.cluster
 import dg.lib.openshift
 import dg.utils.download
@@ -37,7 +37,7 @@ from dg.utils.logging import loglevel_command
 
 
 @loglevel_command(
-    context_settings=dg.lib.click.create_default_map_from_dict(
+    context_settings=dg.lib.click.utils.create_default_map_from_dict(
         dg.config.cluster_credentials_manager.cluster_credentials_manager.get_current_credentials()
     )
 )
@@ -91,8 +91,8 @@ def install_cloud_pak_for_data(
 
     cloud_pak_for_data_assembly_build_type = CloudPakForDataAssemblyBuildType[build_type.upper()]
 
-    dg.lib.click.check_cloud_pak_for_data_options(ctx, cloud_pak_for_data_assembly_build_type, locals().copy())
-    dg.lib.click.log_in_to_openshift_cluster(ctx, locals().copy())
+    dg.lib.click.utils.check_cloud_pak_for_data_options(ctx, cloud_pak_for_data_assembly_build_type, locals().copy())
+    dg.lib.click.utils.log_in_to_openshift_cluster(ctx, locals().copy())
 
     override_yaml_file_path = dg.config.data_gate_configuration_manager.get_deps_directory_path() / "override.yaml"
     cloud_pak_for_data_manager = CloudPakForDataManagerFactory.get_cloud_pak_for_data_manager(

--- a/dg/commands/cluster/install_data_gate.py
+++ b/dg/commands/cluster/install_data_gate.py
@@ -20,7 +20,7 @@ import semver
 from click_option_group import optgroup
 
 import dg.config.cluster_credentials_manager
-import dg.lib.click
+import dg.lib.click.utils
 import dg.lib.openshift
 import dg.utils.download
 
@@ -35,7 +35,7 @@ from dg.utils.logging import loglevel_command
 
 
 @loglevel_command(
-    context_settings=dg.lib.click.create_default_map_from_dict(
+    context_settings=dg.lib.click.utils.create_default_map_from_dict(
         dg.config.cluster_credentials_manager.cluster_credentials_manager.get_current_credentials()
     )
 )
@@ -89,8 +89,8 @@ def install_data_gate(
 
     cloud_pak_for_data_assembly_build_type = CloudPakForDataAssemblyBuildType[build_type.upper()]
 
-    dg.lib.click.check_cloud_pak_for_data_options(ctx, cloud_pak_for_data_assembly_build_type, locals().copy())
-    dg.lib.click.log_in_to_openshift_cluster(ctx, locals().copy())
+    dg.lib.click.utils.check_cloud_pak_for_data_options(ctx, cloud_pak_for_data_assembly_build_type, locals().copy())
+    dg.lib.click.utils.log_in_to_openshift_cluster(ctx, locals().copy())
 
     cloud_pak_for_data_manager = CloudPakForDataManagerFactory.get_cloud_pak_for_data_manager(
         semver.VersionInfo.parse(version)

--- a/dg/commands/cluster/install_db2.py
+++ b/dg/commands/cluster/install_db2.py
@@ -20,7 +20,7 @@ import semver
 from click_option_group import optgroup
 
 import dg.config.cluster_credentials_manager
-import dg.lib.click
+import dg.lib.click.utils
 import dg.lib.cloud_pak_for_data.cpd_manager_factory
 import dg.lib.openshift
 import dg.utils.download
@@ -36,7 +36,7 @@ from dg.utils.logging import loglevel_command
 
 
 @loglevel_command(
-    context_settings=dg.lib.click.create_default_map_from_dict(
+    context_settings=dg.lib.click.utils.create_default_map_from_dict(
         dg.config.cluster_credentials_manager.cluster_credentials_manager.get_current_credentials()
     )
 )
@@ -97,8 +97,8 @@ def install_db2(
 
     cloud_pak_for_data_assembly_build_type = CloudPakForDataAssemblyBuildType[build_type.upper()]
 
-    dg.lib.click.check_cloud_pak_for_data_options(ctx, cloud_pak_for_data_assembly_build_type, locals().copy())
-    dg.lib.click.log_in_to_openshift_cluster(ctx, locals().copy())
+    dg.lib.click.utils.check_cloud_pak_for_data_options(ctx, cloud_pak_for_data_assembly_build_type, locals().copy())
+    dg.lib.click.utils.log_in_to_openshift_cluster(ctx, locals().copy())
 
     cloud_pak_for_data_manager = CloudPakForDataManagerFactory.get_cloud_pak_for_data_manager(
         semver.VersionInfo.parse(version)

--- a/dg/commands/cluster/login.py
+++ b/dg/commands/cluster/login.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 import dg.config.cluster_credentials_manager
-import dg.lib.click
+import dg.lib.click.utils
 import dg.lib.fyre.cluster.fyre_cluster_factory  # required to register FYREClusterFactory object
 import dg.lib.ibmcloud.cluster.ibmcloud_cluster_factory  # required to register IBMCloudClusterFactory object
 
@@ -22,7 +22,7 @@ from dg.utils.logging import loglevel_command
 
 
 @loglevel_command(
-    context_settings=dg.lib.click.create_default_map_from_dict(
+    context_settings=dg.lib.click.utils.create_default_map_from_dict(
         dg.config.cluster_credentials_manager.cluster_credentials_manager.get_current_credentials()
     )
 )

--- a/dg/commands/fyre/__init__.py
+++ b/dg/commands/fyre/__init__.py
@@ -12,22 +12,16 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import pathlib
+import sys
 
 import click
 
 import dg.config
-import dg.lib.click as dgclick
-
-
-def get_click_multi_command_class() -> type[click.Command]:
-    return dgclick.create_click_multi_command_class(
-        dgclick.import_packages_and_modules(__name__, pathlib.Path(__file__).parent)
-    )
+from dg.lib.click.lazy_loading_multi_command import create_click_multi_command_class
 
 
 @click.command(
-    cls=get_click_multi_command_class(),
+    cls=create_click_multi_command_class(sys.modules[__name__]),
     hidden=dg.config.data_gate_configuration_manager.are_fyre_commands_hidden(),
 )
 def fyre():

--- a/dg/commands/fyre/cluster/__init__.py
+++ b/dg/commands/fyre/cluster/__init__.py
@@ -12,20 +12,14 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import pathlib
+import sys
 
 import click
 
-import dg.lib.click as dgclick
+from dg.lib.click.lazy_loading_multi_command import create_click_multi_command_class
 
 
-def get_click_multi_command_class() -> type[click.Command]:
-    return dgclick.create_click_multi_command_class(
-        dgclick.import_packages_and_modules(__name__, pathlib.Path(__file__).parent)
-    )
-
-
-@click.command(cls=get_click_multi_command_class())
+@click.command(cls=create_click_multi_command_class(sys.modules[__name__]))
 def cluster():
     """Manage a FYRE OpenShift cluster"""
 

--- a/dg/commands/fyre/cluster/copy_ssh_key.py
+++ b/dg/commands/fyre/cluster/copy_ssh_key.py
@@ -17,13 +17,13 @@ import subprocess
 import click
 
 import dg.config.cluster_credentials_manager
-import dg.lib.click
+import dg.lib.click.utils
 
 from dg.utils.logging import loglevel_command
 
 
 @loglevel_command(
-    context_settings=dg.lib.click.create_default_map_from_dict(
+    context_settings=dg.lib.click.utils.create_default_map_from_dict(
         dg.config.cluster_credentials_manager.cluster_credentials_manager.get_current_credentials()
     )
 )

--- a/dg/commands/fyre/cluster/create.py
+++ b/dg/commands/fyre/cluster/create.py
@@ -20,7 +20,7 @@ import click
 import requests
 
 import dg.config
-import dg.lib.click
+import dg.lib.click.utils
 import dg.utils.network
 
 from dg.lib.error import DataGateCLIException
@@ -30,7 +30,7 @@ IBM_FYRE_DEPLOY_OPENSHIFT_CLUSTER_URL: Final[str] = "https://api.fyre.ibm.com/re
 
 
 @loglevel_command(
-    context_settings=dg.lib.click.create_default_map_from_json_file(
+    context_settings=dg.lib.click.utils.create_default_map_from_json_file(
         dg.config.data_gate_configuration_manager.get_dg_credentials_file_path()
     )
 )

--- a/dg/commands/fyre/cluster/get_cluster_access_token.py
+++ b/dg/commands/fyre/cluster/get_cluster_access_token.py
@@ -15,14 +15,14 @@
 import click
 
 import dg.config.cluster_credentials_manager
-import dg.lib.click
+import dg.lib.click.utils
 
 from dg.lib.fyre.cluster.fyre_cluster_factory import fyre_cluster_factory
 from dg.utils.logging import loglevel_command
 
 
 @loglevel_command(
-    context_settings=dg.lib.click.create_default_map_from_dict(
+    context_settings=dg.lib.click.utils.create_default_map_from_dict(
         dg.config.cluster_credentials_manager.cluster_credentials_manager.get_current_credentials()
     )
 )

--- a/dg/commands/fyre/cluster/init_node_for_data_gate.py
+++ b/dg/commands/fyre/cluster/init_node_for_data_gate.py
@@ -18,14 +18,14 @@ import click
 
 import dg.config
 import dg.config.cluster_credentials_manager
-import dg.lib.click
+import dg.lib.click.utils
 import dg.utils.ssh
 
 from dg.utils.logging import loglevel_command
 
 
 @loglevel_command(
-    context_settings=dg.lib.click.create_default_map_from_dict(
+    context_settings=dg.lib.click.utils.create_default_map_from_dict(
         dg.config.cluster_credentials_manager.cluster_credentials_manager.get_current_credentials()
     )
 )

--- a/dg/commands/fyre/cluster/init_node_for_db2.py
+++ b/dg/commands/fyre/cluster/init_node_for_db2.py
@@ -19,7 +19,7 @@ from typing import Union
 import click
 
 import dg.config.cluster_credentials_manager
-import dg.lib.click
+import dg.lib.click.utils
 import dg.lib.fyre.openshift
 import dg.utils.network
 
@@ -27,7 +27,7 @@ from dg.utils.logging import loglevel_command
 
 
 @loglevel_command(
-    context_settings=dg.lib.click.create_default_map_from_dict(
+    context_settings=dg.lib.click.utils.create_default_map_from_dict(
         dg.config.cluster_credentials_manager.cluster_credentials_manager.get_current_credentials()
     )
 )
@@ -59,10 +59,10 @@ def init_node_for_db2(
     """Initialize a worker node before creating a Db2 instance"""
 
     if dg.utils.network.is_hostname_localhost(infrastructure_node_hostname):
-        dg.lib.click.log_in_to_openshift_cluster(ctx, locals().copy())
+        dg.lib.click.utils.log_in_to_openshift_cluster(ctx, locals().copy())
         dg.lib.fyre.openshift.init_node_for_db2(node, db2_edition, use_host_path_storage)
     else:
-        oc_login_command_for_remote_host = dg.lib.click.get_oc_login_command_for_remote_host(ctx, locals().copy())
+        oc_login_command_for_remote_host = dg.lib.click.utils.get_oc_login_command_for_remote_host(ctx, locals().copy())
 
         asyncio.get_event_loop().run_until_complete(
             dg.lib.fyre.openshift.init_node_for_db2_from_remote_host(

--- a/dg/commands/fyre/cluster/install_nfs_storage_class.py
+++ b/dg/commands/fyre/cluster/install_nfs_storage_class.py
@@ -19,7 +19,7 @@ from typing import Union
 import click
 
 import dg.config.cluster_credentials_manager
-import dg.lib.click
+import dg.lib.click.utils
 import dg.lib.fyre.nfs
 import dg.utils.network
 
@@ -27,7 +27,7 @@ from dg.utils.logging import loglevel_command
 
 
 @loglevel_command(
-    context_settings=dg.lib.click.create_default_map_from_dict(
+    context_settings=dg.lib.click.utils.create_default_map_from_dict(
         dg.config.cluster_credentials_manager.cluster_credentials_manager.get_current_credentials()
     )
 )
@@ -54,10 +54,10 @@ def install_nfs_storage_class(
     """Install NFS storage class"""
 
     if dg.utils.network.is_hostname_localhost(infrastructure_node_hostname):
-        dg.lib.click.log_in_to_openshift_cluster(ctx, locals().copy())
+        dg.lib.click.utils.log_in_to_openshift_cluster(ctx, locals().copy())
         dg.lib.fyre.nfs.install_nfs_storage_class(ibm_github_api_key)
     else:
-        oc_login_command_for_remote_host = dg.lib.click.get_oc_login_command_for_remote_host(ctx, locals().copy())
+        oc_login_command_for_remote_host = dg.lib.click.utils.get_oc_login_command_for_remote_host(ctx, locals().copy())
 
         asyncio.get_event_loop().run_until_complete(
             dg.lib.fyre.nfs.install_nfs_storage_class_on_remote_host(

--- a/dg/commands/fyre/cluster/login.py
+++ b/dg/commands/fyre/cluster/login.py
@@ -17,14 +17,14 @@ from typing import Union
 import click
 
 import dg.config.cluster_credentials_manager
-import dg.lib.click
+import dg.lib.click.utils
 
 from dg.lib.fyre.cluster.fyre_cluster_factory import fyre_cluster_factory
 from dg.utils.logging import loglevel_command
 
 
 @loglevel_command(
-    context_settings=dg.lib.click.create_default_map_from_dict(
+    context_settings=dg.lib.click.utils.create_default_map_from_dict(
         dg.config.cluster_credentials_manager.cluster_credentials_manager.get_current_credentials()
     )
 )

--- a/dg/commands/fyre/cluster/ls.py
+++ b/dg/commands/fyre/cluster/ls.py
@@ -20,7 +20,7 @@ import requests
 from tabulate import tabulate
 
 import dg.config
-import dg.lib.click
+import dg.lib.click.utils
 import dg.utils.network
 
 from dg.lib.error import DataGateCLIException
@@ -32,7 +32,7 @@ IBM_FYRE_SHOW_OPENSHIFT_CLUSTERS_URL: Final[
 
 
 @loglevel_command(
-    context_settings=dg.lib.click.create_default_map_from_json_file(
+    context_settings=dg.lib.click.utils.create_default_map_from_json_file(
         dg.config.data_gate_configuration_manager.get_dg_credentials_file_path()
     )
 )

--- a/dg/commands/fyre/cluster/reboot.py
+++ b/dg/commands/fyre/cluster/reboot.py
@@ -20,7 +20,7 @@ import click
 import requests
 
 import dg.config
-import dg.lib.click
+import dg.lib.click.utils
 import dg.utils.network
 
 from dg.lib.error import DataGateCLIException
@@ -30,7 +30,7 @@ IBM_FYRE_REBOOT_CLUSTER_URL: Final[str] = "https://api.fyre.ibm.com/rest/v1/?ope
 
 
 @loglevel_command(
-    context_settings=dg.lib.click.create_default_map_from_json_file(
+    context_settings=dg.lib.click.utils.create_default_map_from_json_file(
         dg.config.data_gate_configuration_manager.get_dg_credentials_file_path()
     )
 )

--- a/dg/commands/fyre/cluster/rm.py
+++ b/dg/commands/fyre/cluster/rm.py
@@ -21,7 +21,7 @@ import requests
 
 import dg.config
 import dg.config.cluster_credentials_manager
-import dg.lib.click
+import dg.lib.click.utils
 import dg.utils.network
 
 from dg.lib.error import DataGateCLIException
@@ -31,7 +31,7 @@ IBM_FYRE_DELETE_CLUSTER_URL: Final[str] = "https://api.fyre.ibm.com/rest/v1/?ope
 
 
 @loglevel_command(
-    context_settings=dg.lib.click.create_default_map_from_json_file(
+    context_settings=dg.lib.click.utils.create_default_map_from_json_file(
         dg.config.data_gate_configuration_manager.get_dg_credentials_file_path()
     )
 )

--- a/dg/commands/ibmcloud/__init__.py
+++ b/dg/commands/ibmcloud/__init__.py
@@ -12,20 +12,14 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import pathlib
+import sys
 
 import click
 
-import dg.lib.click as dgclick
+from dg.lib.click.lazy_loading_multi_command import create_click_multi_command_class
 
 
-def get_click_multi_command_class() -> type[click.Command]:
-    return dgclick.create_click_multi_command_class(
-        dgclick.import_packages_and_modules(__name__, pathlib.Path(__file__).parent)
-    )
-
-
-@click.command(cls=get_click_multi_command_class())
+@click.command(cls=create_click_multi_command_class(sys.modules[__name__]))
 def ibmcloud():
     """IBM Cloud-specific commands"""
 

--- a/dg/commands/ibmcloud/cluster/__init__.py
+++ b/dg/commands/ibmcloud/cluster/__init__.py
@@ -12,20 +12,14 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import pathlib
+import sys
 
 import click
 
-import dg.lib.click as dgclick
+from dg.lib.click.lazy_loading_multi_command import create_click_multi_command_class
 
 
-def get_click_multi_command_class() -> type[click.Command]:
-    return dgclick.create_click_multi_command_class(
-        dgclick.import_packages_and_modules(__name__, pathlib.Path(__file__).parent)
-    )
-
-
-@click.command(cls=get_click_multi_command_class())
+@click.command(cls=create_click_multi_command_class(sys.modules[__name__]))
 def cluster():
     """Manage a RedHat OpenShift cluster"""
 

--- a/dg/commands/ibmcloud/nuclear/__init__.py
+++ b/dg/commands/ibmcloud/nuclear/__init__.py
@@ -12,22 +12,16 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import pathlib
+import sys
 
 import click
 
 import dg.config
-import dg.lib.click as dgclick
-
-
-def get_click_multi_command_class() -> type[click.Command]:
-    return dgclick.create_click_multi_command_class(
-        dgclick.import_packages_and_modules(__name__, pathlib.Path(__file__).parent)
-    )
+from dg.lib.click.lazy_loading_multi_command import create_click_multi_command_class
 
 
 @click.command(
-    cls=get_click_multi_command_class(),
+    cls=create_click_multi_command_class(sys.modules[__name__]),
     hidden=dg.config.data_gate_configuration_manager.are_nuclear_commands_hidden(),
 )
 def nuclear():

--- a/dg/dg.py
+++ b/dg/dg.py
@@ -21,6 +21,10 @@ import dg.commands
 import dg.utils.debugger
 import dg.utils.logging
 
+from dg.lib.click.lazy_loading_multi_command import (
+    create_click_multi_command_class,
+)
+
 dg.utils.logging.init_root_logger()
 
 if dg.utils.debugger.is_debugpy_running() and (len(sys.argv) == 2):
@@ -35,7 +39,10 @@ if dg.utils.debugger.is_debugpy_running() and (len(sys.argv) == 2):
         sys.argv = [sys.argv[0]] + sys.argv[1].split()
 
 
-@click.group(cls=dg.commands.get_click_multi_command_class(), invoke_without_command=True)
+@click.group(
+    cls=create_click_multi_command_class(dg.commands),
+    invoke_without_command=True,
+)
 @click.option("--version", is_flag=True, help="Show the version number of the Data Gate CLI")
 @click.pass_context
 def cli(ctx: click.Context, version: bool):

--- a/dg/lib/click/lazy_loading_multi_command.py
+++ b/dg/lib/click/lazy_loading_multi_command.py
@@ -1,0 +1,178 @@
+#  Copyright 2020 IBM Corporation
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import importlib
+import logging
+import pathlib
+
+from types import ModuleType
+from typing import Optional
+
+import click
+
+logger = logging.getLogger(__name__)
+
+
+class CommandData:
+    def __init__(self, command_names: list[str], commands: dict[str, click.Command]):
+        super().__init__()
+
+        self.command_names = command_names
+        self.commands = commands
+
+
+def create_click_multi_command_class(package: ModuleType) -> type[click.Command]:
+    """Creates a definition of a subclass of click.MultiCommand
+
+    This method creates a definition of a subclass of click.MultiCommand
+    providing Click commands found in the Python modules of the given Python
+    package.
+
+    Parameters
+    ----------
+    package
+        Python package
+
+    Returns
+    -------
+    click.Command
+        Definition of a subclass of click.MultiCommand
+    """
+
+    package_name = package.__name__
+    package_directory_path = pathlib.Path(package.__file__).parent
+
+    class LazyLoadingMultiCommand(click.MultiCommand):
+        def __call__(self, *args, **kwargs):
+            """Handle exceptions raised by Click commands"""
+
+            try:
+                return self.main(*args, **kwargs)
+            except Exception as exception:
+                click.ClickException(str(exception)).show()
+
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+
+            self._command_data: Optional[CommandData] = None
+
+        def get_command(self, ctx: click.Context, cmd_name: str) -> click.Command:
+            self._initialize_commands_if_required()
+
+            if cmd_name not in self._command_data.commands:
+                raise click.ClickException("Unknown command")
+
+            return self._command_data.commands[cmd_name]
+
+        def list_commands(self, ctx: click.Context) -> list[str]:
+            self._initialize_commands_if_required()
+
+            return self._command_data.command_names if self._command_data is not None else []
+
+        def _get_click_commands(self, module: ModuleType) -> dict[str, click.Command]:
+            """Returns Click commands within the given Python module
+
+            This method searches the given Python module for Click commands.
+
+            Parameters
+            ----------
+            module
+                Python module
+
+            Returns
+            -------
+            dict[str, click.Command]
+                dictionary associating Click command names with Click commands
+            """
+
+            commands: dict[str, click.Command] = {}
+
+            for attributeName in dir(module):
+                attribute = getattr(module, attributeName)
+
+                if isinstance(attribute, click.Command):
+                    command_name = attributeName.replace("_", "-")
+
+                    commands[command_name] = attribute
+
+            return commands
+
+        def _import_packages_and_modules(self) -> dict[str, ModuleType]:
+            """Imports all subpackages and submodules within a Python package
+
+            Parameters
+            ----------
+            package_name
+                name of the Python package (__name__)
+            package_directory_path
+                path of the directory of the Python package (__file__)
+
+            Returns
+            -------
+            dict[str, ModuleType]
+                dictionary associating names of imported modules with imported modules
+            """
+
+            modules: dict[str, ModuleType] = {}
+
+            for file_path in package_directory_path.iterdir():
+                if file_path.is_dir() and (file_path / "__init__.py").exists():
+                    package_or_module_name = file_path.name
+
+                    logger.debug("Importing package {}.{}".format(package_name, package_or_module_name))
+                    modules[package_or_module_name] = importlib.import_module(
+                        "{}.{}".format(package_name, package_or_module_name)
+                    )
+                elif file_path.is_file() and (file_path.suffix == ".py") and (file_path.name != "__init__.py"):
+                    package_or_module_name = file_path.name[:-3]
+
+                    logger.debug("Importing module {}.{}".format(package_name, package_or_module_name))
+                    modules[package_or_module_name] = importlib.import_module(
+                        "{}.{}".format(package_name, package_or_module_name)
+                    )
+
+            return modules
+
+        def _initialize_commands_if_required(self):
+            """Creates click.MultiCommand data structures
+
+            This method creates two data structures based on Click commands within
+            the given Python modules:
+
+            - a list of Click command names
+            - a dictionary associating Click command names with Click commands
+
+            Parameters
+            ----------
+            modules
+                Python modules
+            """
+
+            if self._command_data is None:
+                commands: dict[str, click.Command] = {}
+                command_names: list[str] = []
+                modules = self._import_packages_and_modules()
+
+                for module_name, module in modules.items():
+                    module_commands = self._get_click_commands(module)
+
+                    if len(module_commands) != 0:
+                        commands.update(module_commands)
+                        command_names.append(module_name.replace("_", "-"))
+
+                command_names.sort()
+
+                self._command_data = CommandData(command_names, commands)
+
+    return LazyLoadingMultiCommand

--- a/test/commands/adm/test_store_credentials.py
+++ b/test/commands/adm/test_store_credentials.py
@@ -22,7 +22,7 @@ import click.testing
 
 import dg.commands.adm.store_credentials
 import dg.config
-import dg.lib.click
+import dg.lib.click.utils
 
 from dg.dg import cli
 
@@ -31,15 +31,13 @@ class TestStoreCredentialsCommand(unittest.TestCase):
     def test_store_credentials(self):
         """Tests that dg adm store-credentials creates credentials.json"""
 
-        dg_credentials_file_path = (
-            pathlib.Path(tempfile.gettempdir()) / "credentials.json"
-        )
+        dg_credentials_file_path = pathlib.Path(tempfile.gettempdir()) / "credentials.json"
 
         if dg_credentials_file_path.exists():
             os.remove(dg_credentials_file_path)
 
-        dg.config.data_gate_configuration_manager.get_dg_credentials_file_path = (
-            unittest.mock.MagicMock(return_value=dg_credentials_file_path)
+        dg.config.data_gate_configuration_manager.get_dg_credentials_file_path = unittest.mock.MagicMock(
+            return_value=dg_credentials_file_path
         )
 
         # check that key-value pairs were added to credentials.json
@@ -97,7 +95,7 @@ class TestStoreCredentialsCommand(unittest.TestCase):
         self.assertNotIn("ibm_github_api_key", default_map)
 
     def _load_credentials_file(self, dg_credentials_file_path: pathlib.Path):
-        json = dg.lib.click.create_default_map_from_json_file(dg_credentials_file_path)
+        json = dg.lib.click.utils.create_default_map_from_json_file(dg_credentials_file_path)
 
         self.assertIn("default_map", json)
 

--- a/test/commands/cluster/test_cluster_commands.py
+++ b/test/commands/cluster/test_cluster_commands.py
@@ -131,22 +131,14 @@ class TestClusterCommands(unittest.TestCase):
 
         self._add_cluster(cluster_1_data)
         self.assertEqual(
-            len(
-                cluster_credentials_manager.get_clusters_file_contents_with_default()[
-                    "clusters"
-                ]
-            ),
+            len(cluster_credentials_manager.get_clusters_file_contents_with_default()["clusters"]),
             1,
         )
 
         # remove cluster-1
         self._rm_cluster(cluster_1_data["server"])
         self.assertEqual(
-            len(
-                cluster_credentials_manager.get_clusters_file_contents_with_default()[
-                    "clusters"
-                ]
-            ),
+            len(cluster_credentials_manager.get_clusters_file_contents_with_default()["clusters"]),
             0,
         )
 

--- a/test/commands/fyre/cluster/test_add.py
+++ b/test/commands/fyre/cluster/test_add.py
@@ -86,11 +86,7 @@ class TestAddClusterCommands(unittest.TestCase):
 
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(
-            len(
-                cluster_credentials_manager.get_clusters_file_contents_with_default()[
-                    "clusters"
-                ]
-            ),
+            len(cluster_credentials_manager.get_clusters_file_contents_with_default()["clusters"]),
             num_expected_cluster,
         )
 
@@ -149,8 +145,6 @@ class TestAddClusterCommands(unittest.TestCase):
         )
 
         self.assertEqual(returned_cluster_data["password"], cluster_data["password"])
-        self.assertEqual(
-            returned_cluster_data["type"], dg.lib.fyre.cluster.CLUSTER_TYPE
-        )
+        self.assertEqual(returned_cluster_data["type"], dg.lib.fyre.cluster.CLUSTER_TYPE)
 
         self.assertEqual(returned_cluster_data["username"], "kubeadmin")

--- a/test/commands/ibmcloud/cluster/test_add.py
+++ b/test/commands/ibmcloud/cluster/test_add.py
@@ -69,9 +69,7 @@ class TestAddClusterCommands(unittest.TestCase):
         server = cluster_data["server"]
 
         dg.lib.ibmcloud.status.execute_ibmcloud_command = unittest.mock.MagicMock(
-            return_value=dg.utils.process.ProcessResult(
-                stderr="", stdout=f'{{"serverURL": "{server}"}}', return_code=0
-            )
+            return_value=dg.utils.process.ProcessResult(stderr="", stdout=f'{{"serverURL": "{server}"}}', return_code=0)
         )
 
         runner = click.testing.CliRunner()
@@ -93,11 +91,7 @@ class TestAddClusterCommands(unittest.TestCase):
 
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(
-            len(
-                cluster_credentials_manager.get_clusters_file_contents_with_default()[
-                    "clusters"
-                ]
-            ),
+            len(cluster_credentials_manager.get_clusters_file_contents_with_default()["clusters"]),
             num_expected_cluster,
         )
 

--- a/test/commands/ibmcloud/test_ibmcloud_common.py
+++ b/test/commands/ibmcloud/test_ibmcloud_common.py
@@ -32,9 +32,7 @@ class TestIBMCloudCommon(unittest.TestCase):
         "dg.lib.ibmcloud.iam.execute_ibmcloud_command",
         return_value=ProcessResult(
             stderr="",
-            stdout=(
-                Path(__file__).parent / "dependencies/ibmcloud_generate_api_key.json"
-            ).read_text(),
+            stdout=(Path(__file__).parent / "dependencies/ibmcloud_generate_api_key.json").read_text(),
             return_code=0,
         ),
     )
@@ -46,9 +44,7 @@ class TestIBMCloudCommon(unittest.TestCase):
         "dg.lib.ibmcloud.iam.execute_ibmcloud_command",
         return_value=ProcessResult(
             stderr="",
-            stdout=(
-                Path(__file__).parent / "dependencies/ibmcloud_api_keys.json"
-            ).read_text(),
+            stdout=(Path(__file__).parent / "dependencies/ibmcloud_api_keys.json").read_text(),
             return_code=0,
         ),
     )
@@ -61,9 +57,7 @@ class TestIBMCloudCommon(unittest.TestCase):
         "dg.lib.ibmcloud.vlan.execute_ibmcloud_command",
         return_value=ProcessResult(
             stderr="",
-            stdout=(
-                Path(__file__).parent / "dependencies/ibmcloud_list_vlans.json"
-            ).read_text(),
+            stdout=(Path(__file__).parent / "dependencies/ibmcloud_list_vlans.json").read_text(),
             return_code=0,
         ),
     )
@@ -75,9 +69,7 @@ class TestIBMCloudCommon(unittest.TestCase):
         "dg.lib.ibmcloud.vlan.execute_ibmcloud_command",
         return_value=ProcessResult(
             stderr="",
-            stdout=(
-                Path(__file__).parent / "dependencies/ibmcloud_list_vlans.json"
-            ).read_text(),
+            stdout=(Path(__file__).parent / "dependencies/ibmcloud_list_vlans.json").read_text(),
             return_code=0,
         ),
     )
@@ -89,9 +81,7 @@ class TestIBMCloudCommon(unittest.TestCase):
         "dg.lib.ibmcloud.status.execute_ibmcloud_command",
         return_value=ProcessResult(
             stderr="",
-            stdout=(
-                Path(__file__).parent / "dependencies/ibmcloud_oc_cluster_status.json"
-            ).read_text(),
+            stdout=(Path(__file__).parent / "dependencies/ibmcloud_oc_cluster_status.json").read_text(),
             return_code=0,
         ),
     )
@@ -102,9 +92,7 @@ class TestIBMCloudCommon(unittest.TestCase):
         "dg.lib.ibmcloud.status.execute_ibmcloud_command",
         return_value=ProcessResult(
             stderr="",
-            stdout=(
-                Path(__file__).parent / "dependencies/ibmcloud_oc_cluster_status_2.json"
-            ).read_text(),
+            stdout=(Path(__file__).parent / "dependencies/ibmcloud_oc_cluster_status_2.json").read_text(),
             return_code=0,
         ),
     )
@@ -115,9 +103,7 @@ class TestIBMCloudCommon(unittest.TestCase):
         "dg.lib.ibmcloud.install.execute_ibmcloud_command",
         return_value=ProcessResult(
             stderr="",
-            stdout=Path(
-                "test/dependencies/ibmcloud_catalog_search_pak.json"
-            ).read_text(),
+            stdout=Path("test/dependencies/ibmcloud_catalog_search_pak.json").read_text(),
             return_code=0,
         ),
     )

--- a/test/commands/ibmcloud/test_oc.py
+++ b/test/commands/ibmcloud/test_oc.py
@@ -10,11 +10,7 @@ from dg.lib.ibmcloud.oc import get_latest_supported_openshift_version
 class TestIBMCloudOpenShift(unittest.TestCase):
     @patch(
         "dg.lib.ibmcloud.oc._get_oc_versions_as_json",
-        return_value=json.loads(
-            (
-                Path(__file__).parent / "dependencies/ibmcloud_oc_versions.json"
-            ).read_text()
-        ),
+        return_value=json.loads((Path(__file__).parent / "dependencies/ibmcloud_oc_versions.json").read_text()),
     )
     def test_get_openshift_version(self, test_mock):
         result = get_latest_supported_openshift_version()

--- a/test/lib/fyre/test_network.py
+++ b/test/lib/fyre/test_network.py
@@ -13,9 +13,7 @@ class TestNetworkUtilities(unittest.TestCase):
         ipv4_addresses = dg.utils.network.parse_hostname_result(hostname_result)
 
         self.assertEqual(
-            dg.lib.fyre.network.get_private_ip_address_of_infrastructure_node(
-                ipv4_addresses
-            ),
+            dg.lib.fyre.network.get_private_ip_address_of_infrastructure_node(ipv4_addresses),
             ipaddress.ip_address("10.0.0.1"),
         )
 


### PR DESCRIPTION
This pull request contains the following changes:

- Add `LazyLoadingMultiCommand` class supporting lazy loading of Click commands based on previous `MultiCommand` class and functions in `dg.lib.click` module (previously, all Click commands were imported during program initialization)
- Move logic from `dg.lib.click` module not related to `LazyLoadingMultiCommand` class to `dg.lib.click.utils` module
- Remove superfluous `get_click_multi_command_class()` function in `__init__.py` files
- Format unit tests files (should have been done as part of [PR 19](https://github.com/IBM/data-gate-cli/pull/19))