### PR TITLE
Add support for automatically sorting imports on save

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,9 @@
 {
+	"[python]": {
+		"editor.codeActionsOnSave": {
+			"source.organizeImports": true
+		}
+	},
 	"files.exclude": {
 		"**/__pycache__": true,
 		".vscode/.ropeproject": true,
@@ -6,7 +11,8 @@
 	},
 	"python.analysis.typeCheckingMode": "basic",
 	"python.formatting.blackArgs": [
-		"--line-length=120"
+		"--line-length",
+		"120"
 	],
 	"python.formatting.provider": "black",
 	"python.linting.enabled": true,

--- a/README.md
+++ b/README.md
@@ -122,7 +122,9 @@ import sys
 
 import click
 
-from dg.lib.click.lazy_loading_multi_command import create_click_multi_command_class
+from dg.lib.click.lazy_loading_multi_command import (
+    create_click_multi_command_class,
+)
 
 
 @click.command(cls=create_click_multi_command_class(sys.modules[__name__]))

--- a/dg/commands/adm/__init__.py
+++ b/dg/commands/adm/__init__.py
@@ -16,7 +16,9 @@ import sys
 
 import click
 
-from dg.lib.click.lazy_loading_multi_command import create_click_multi_command_class
+from dg.lib.click.lazy_loading_multi_command import (
+    create_click_multi_command_class,
+)
 
 
 @click.command(cls=create_click_multi_command_class(sys.modules[__name__]))

--- a/dg/commands/adm/config/__init__.py
+++ b/dg/commands/adm/config/__init__.py
@@ -16,7 +16,9 @@ import sys
 
 import click
 
-from dg.lib.click.lazy_loading_multi_command import create_click_multi_command_class
+from dg.lib.click.lazy_loading_multi_command import (
+    create_click_multi_command_class,
+)
 
 
 @click.command(cls=create_click_multi_command_class(sys.modules[__name__]))

--- a/dg/commands/cluster/__init__.py
+++ b/dg/commands/cluster/__init__.py
@@ -16,7 +16,9 @@ import sys
 
 import click
 
-from dg.lib.click.lazy_loading_multi_command import create_click_multi_command_class
+from dg.lib.click.lazy_loading_multi_command import (
+    create_click_multi_command_class,
+)
 
 
 @click.command(cls=create_click_multi_command_class(sys.modules[__name__]))

--- a/dg/commands/fyre/__init__.py
+++ b/dg/commands/fyre/__init__.py
@@ -17,7 +17,10 @@ import sys
 import click
 
 import dg.config
-from dg.lib.click.lazy_loading_multi_command import create_click_multi_command_class
+
+from dg.lib.click.lazy_loading_multi_command import (
+    create_click_multi_command_class,
+)
 
 
 @click.command(

--- a/dg/commands/fyre/cluster/__init__.py
+++ b/dg/commands/fyre/cluster/__init__.py
@@ -16,7 +16,9 @@ import sys
 
 import click
 
-from dg.lib.click.lazy_loading_multi_command import create_click_multi_command_class
+from dg.lib.click.lazy_loading_multi_command import (
+    create_click_multi_command_class,
+)
 
 
 @click.command(cls=create_click_multi_command_class(sys.modules[__name__]))

--- a/dg/commands/ibmcloud/__init__.py
+++ b/dg/commands/ibmcloud/__init__.py
@@ -16,7 +16,9 @@ import sys
 
 import click
 
-from dg.lib.click.lazy_loading_multi_command import create_click_multi_command_class
+from dg.lib.click.lazy_loading_multi_command import (
+    create_click_multi_command_class,
+)
 
 
 @click.command(cls=create_click_multi_command_class(sys.modules[__name__]))

--- a/dg/commands/ibmcloud/cluster/__init__.py
+++ b/dg/commands/ibmcloud/cluster/__init__.py
@@ -16,7 +16,9 @@ import sys
 
 import click
 
-from dg.lib.click.lazy_loading_multi_command import create_click_multi_command_class
+from dg.lib.click.lazy_loading_multi_command import (
+    create_click_multi_command_class,
+)
 
 
 @click.command(cls=create_click_multi_command_class(sys.modules[__name__]))

--- a/dg/commands/ibmcloud/nuclear/__init__.py
+++ b/dg/commands/ibmcloud/nuclear/__init__.py
@@ -17,7 +17,10 @@ import sys
 import click
 
 import dg.config
-from dg.lib.click.lazy_loading_multi_command import create_click_multi_command_class
+
+from dg.lib.click.lazy_loading_multi_command import (
+    create_click_multi_command_class,
+)
 
 
 @click.command(


### PR DESCRIPTION
This pull request contains the following changes:

- Add support for automatically sorting imports on save in Visual Studio Code
- Sort imports of several `__init__.py` files