### PR TITLE
Use Click 8

### DIFF
--- a/dg/deps/autocomplete/dg-autocomplete-bash.sh
+++ b/dg/deps/autocomplete/dg-autocomplete-bash.sh
@@ -1,21 +1,29 @@
 _dg_completion() {
-    local IFS=$'
-'
-    COMPREPLY=( $( env COMP_WORDS="${COMP_WORDS[*]}" \
-                   COMP_CWORD=$COMP_CWORD \
-                   _DG_COMPLETE=complete $1 ) )
+    local IFS=$'\n'
+    local response
+
+    response=$(env COMP_WORDS="${COMP_WORDS[*]}" COMP_CWORD=$COMP_CWORD _DG_COMPLETE=bash_complete $1)
+
+    for completion in $response; do
+        IFS=',' read type value <<< "$completion"
+
+        if [[ $type == 'dir' ]]; then
+            COMREPLY=()
+            compopt -o dirnames
+        elif [[ $type == 'file' ]]; then
+            COMREPLY=()
+            compopt -o default
+        elif [[ $type == 'plain' ]]; then
+            COMPREPLY+=($value)
+        fi
+    done
+
     return 0
 }
 
-_dg_completionetup() {
-    local COMPLETION_OPTIONS=""
-    local BASH_VERSION_ARR=(${BASH_VERSION//./ })
-    # Only BASH version 4.4 and later have the nosort option.
-    if [ ${BASH_VERSION_ARR[0]} -gt 4 ] || ([ ${BASH_VERSION_ARR[0]} -eq 4 ] && [ ${BASH_VERSION_ARR[1]} -ge 4 ]); then
-        COMPLETION_OPTIONS="-o nosort"
-    fi
-
-    complete $COMPLETION_OPTIONS -F _dg_completion dg
+_dg_completion_setup() {
+    complete -o nosort -F _dg_completion dg
 }
 
-_dg_completionetup;
+_dg_completion_setup;
+

--- a/dg/deps/autocomplete/dg-autocomplete-zsh.sh
+++ b/dg/deps/autocomplete/dg-autocomplete-zsh.sh
@@ -6,17 +6,20 @@ _dg_completion() {
     local -a response
     (( ! $+commands[dg] )) && return 1
 
-    response=("${(@f)$( env COMP_WORDS="${words[*]}" \
-                        COMP_CWORD=$((CURRENT-1)) \
-                        _DG_COMPLETE="complete_zsh" \
-                        dg )}")
+    response=("${(@f)$(env COMP_WORDS="${words[*]}" COMP_CWORD=$((CURRENT-1)) _DG_COMPLETE=zsh_complete dg)}")
 
-    for key descr in ${(kv)response}; do
-      if [[ "$descr" == "_" ]]; then
-          completions+=("$key")
-      else
-          completions_with_descriptions+=("$key":"$descr")
-      fi
+    for type key descr in ${response}; do
+        if [[ "$type" == "plain" ]]; then
+            if [[ "$descr" == "_" ]]; then
+                completions+=("$key")
+            else
+                completions_with_descriptions+=("$key":"$descr")
+            fi
+        elif [[ "$type" == "dir" ]]; then
+            _path_files -/
+        elif [[ "$type" == "file" ]]; then
+            _path_files -f
+        fi
     done
 
     if [ -n "$completions_with_descriptions" ]; then
@@ -26,7 +29,7 @@ _dg_completion() {
     if [ -n "$completions" ]; then
         compadd -U -V unsorted -a completions
     fi
-    compstate[insert]="automenu"
 }
 
 compdef _dg_completion dg;
+

--- a/setup.py
+++ b/setup.py
@@ -12,9 +12,10 @@ setup(
     include_package_data=True,
     install_requires=[
         "asyncssh",
-        "click<8",
-        "colorama",
+        "click",
         "click-option-group",
+        "colorama",
+        "jsonschema",
         "netifaces",
         "pyyaml",
         "requests",


### PR DESCRIPTION
This pull request contains the following changes:

- Use Click 8 as the `click-option-group` package now supports it
- Update shell completion scripts (generated by Click 8)