### PR TITLE
Fix Pylance problems

### DIFF
--- a/dg/commands/ibmcloud/oc/cluster/create.py
+++ b/dg/commands/ibmcloud/oc/cluster/create.py
@@ -189,6 +189,10 @@ def create(
         # (see IBM Cloud support case CS2206770)
         logging.info("Restarting openshift-dns pods")
         cluster = dg.config.cluster_credentials_manager.cluster_credentials_manager.get_cluster(server)
+
+        if cluster is None:
+            raise TypeError()
+
         cluster.login()
 
         execute_oc_command(["project", "openshift-dns"])

--- a/dg/config/data_gate_configuration_manager.py
+++ b/dg/config/data_gate_configuration_manager.py
@@ -270,6 +270,9 @@ class DataGateConfigurationManager:
         if dg_credentials_file_path.exists():
             with open(dg_credentials_file_path) as credentials_file:
                 credentials = json.load(credentials_file)
+
+                if credentials is None:
+                    raise TypeError()
         else:
             credentials = {}
 

--- a/dg/lib/fyre/api_manager.py
+++ b/dg/lib/fyre/api_manager.py
@@ -299,9 +299,10 @@ class OCPPlusAPIManager:
                 ],
             )
 
-        if ocp_plus_cluster_settings.worker_settings_exist():
+        if (
+            worker_node_settings := ocp_plus_cluster_settings.worker_node_settings
+        ) is not None and worker_node_settings.worker_settings_exist():
             worker: WorkerData = {}
-            worker_node_settings = ocp_plus_cluster_settings.worker_node_settings
 
             if worker_node_settings.worker_node_additional_disk_size is not None:
                 worker["additional_disk"] = list(

--- a/dg/lib/fyre/cluster/ocpplus_cluster.py
+++ b/dg/lib/fyre/cluster/ocpplus_cluster.py
@@ -30,6 +30,7 @@ class OCPPlusCluster(AbstractCluster):
     def __init__(self, server: str, cluster_data: ClusterData):
         super().__init__(server, cluster_data)
 
+    # override
     def get_cluster_access_token(self) -> str:
         token = dg.lib.openshift.get_cluster_access_token(
             OPENSHIFT_OAUTH_AUTHORIZATION_ENDPOINT.format(cluster_name=self.cluster_data["cluster_name"]),
@@ -39,6 +40,7 @@ class OCPPlusCluster(AbstractCluster):
 
         return token
 
+    # override
     def login(self):
         dg.lib.openshift.log_in_to_openshift_cluster_with_password(
             self.server, self.cluster_data["username"], self.cluster_data["password"]

--- a/dg/lib/fyre/data/ocpplus_cluster_specification.py
+++ b/dg/lib/fyre/data/ocpplus_cluster_specification.py
@@ -162,4 +162,4 @@ class OCPPlusClusterSpecification:
         self.worker_node_settings = worker_node_settings
 
     def worker_settings_exist(self) -> bool:
-        return self.worker_node_settings.worker_settings_exist()
+        return self.worker_node_settings is not None and self.worker_node_settings.worker_settings_exist()

--- a/dg/lib/ibmcloud/ks/cluster/iks_cluster.py
+++ b/dg/lib/ibmcloud/ks/cluster/iks_cluster.py
@@ -20,10 +20,12 @@ class IKSCluster(AbstractCluster):
     def __init__(self, server: str, cluster_data: ClusterData):
         super().__init__(server, cluster_data)
 
+    # override
     def get_cluster_access_token(self) -> str:
         # TODO implement
         return ""
 
+    # override
     def login(self):
         args = [
             "ks",

--- a/tests/test/commands/cluster/test_cluster_commands.py
+++ b/tests/test/commands/cluster/test_cluster_commands.py
@@ -40,9 +40,11 @@ class UnitTestCluster(AbstractCluster):
     def __init__(self, server: str, cluster_data: ClusterData):
         super().__init__(server, cluster_data)
 
+    # override
     def get_cluster_access_token(self) -> str:
         return ""
 
+    # override
     def login(self):
         pass
 
@@ -114,6 +116,9 @@ class TestClusterCommands(unittest.TestCase):
         cluster = cluster_credentials_manager.get_cluster(cluster_1_data["server"])
 
         self.assertIsNotNone(cluster)
+
+        if cluster is None:
+            raise TypeError()
 
         cluster_data = cluster.get_cluster_data()
 

--- a/tests/test_fyre/test_fyre_commands.py
+++ b/tests/test_fyre/test_fyre_commands.py
@@ -204,6 +204,9 @@ class TestFYRECommands(unittest.TestCase):
 
         self.assertIsNotNone(search_result)
 
+        if search_result is None:
+            raise TypeError()
+
         TestFYRECommands._cluster_name = search_result.group(1)
 
     def _edit_inf_node(self):


### PR DESCRIPTION
This pull request contains the following changes:

- Fix Pylance problems occurring due to a newer Pylance version

Additional information:

The following code seems to be redundant, but Pylance cannot determine that the first method already checks for `None` and therefore creates a warning in Visual Studio Code:

```
self.assertIsNotNone(cluster)

if cluster is None:
    raise TypeError()
```

This issue can be solved with Python 3.10, which will introduce [user-defined type guards](https://www.python.org/dev/peps/pep-0647/).