### PR TITLE
Add support for transferring ownership of a FYRE cluster to another product group

### DIFF
--- a/dg/commands/fyre/cluster/transfer_ownership.py
+++ b/dg/commands/fyre/cluster/transfer_ownership.py
@@ -35,17 +35,24 @@ from dg.utils.logging import loglevel_command
 @click.option("--fyre-api-key", help="FYRE API key (see https://fyre.svl.ibm.com/account)", required=True)
 @click.option("--cluster-name", help="Name of the OCP+ cluster to be transferred", required=True)
 @click.option("--comment", help="Comment")
-@click.option("--new-owner", help="User ID, username, or e-mail address of new owner", required=True)
+@click.option("--new-owner", help="User ID, username, or e-mail address of new owner")
+@click.option("--new-product-group-id", help="ID of new FYRE product group", type=click.INT)
 @click.option("--site", help="OCP+ site", type=click.Choice(["rtp", "svl"]))
+@click.pass_context
 def transfer_ownership(
+    ctx: click.Context,
     fyre_user_name: str,
     fyre_api_key: str,
     cluster_name: str,
     comment: Optional[str],
-    new_owner: str,
+    new_owner: Optional[str],
+    new_product_group: Optional[int],
     site: Optional[str],
 ):
-    """Transfer ownership of an OCP+ cluster"""
+    """Transfer ownership of an OCP+ cluster to a new user and/or product group"""
+
+    if new_owner is None and new_product_group is None:
+        raise click.UsageError("You must set options '--new-owner' and/or '--new-product-group-id'.", ctx)
 
     dg.utils.network.disable_insecure_request_warning()
-    OCPPlusAPIManager(fyre_user_name, fyre_api_key).transfer(cluster_name, new_owner, comment, site)
+    OCPPlusAPIManager(fyre_user_name, fyre_api_key).transfer(cluster_name, new_owner, new_product_group, comment, site)

--- a/dg/lib/fyre/api_manager.py
+++ b/dg/lib/fyre/api_manager.py
@@ -737,7 +737,14 @@ class OCPPlusAPIManager:
             self._fyre_user_name, self._fyre_api_key, site, cluster_name, node_name, "shutdown"
         ).execute_request_put_request()
 
-    def transfer(self, cluster_name: str, new_owner: str, comment: Optional[str], site: Optional[str]):
+    def transfer(
+        self,
+        cluster_name: str,
+        new_owner: Optional[str],
+        new_product_group: Optional[int],
+        comment: Optional[str],
+        site: Optional[str],
+    ):
         """Transfer an OCP+ cluster
 
         Parameters
@@ -746,16 +753,24 @@ class OCPPlusAPIManager:
             Name of the OCP+ cluster to be transferred
         new_owner
             User ID, username, or e-mail address of new owner
+        new_product_group
+            ID of new FYRE product group
         comment
             Comment
         site
             OCP+ site
         """
 
-        ocp_transfer_put_request: OCPTransferPutRequest = {"new_owner": new_owner}
+        ocp_transfer_put_request: OCPTransferPutRequest = {}
 
         if comment is not None:
             ocp_transfer_put_request["comment"] = comment
+
+        if new_owner is not None:
+            ocp_transfer_put_request["new_owner"] = new_owner
+
+        if new_product_group is not None:
+            ocp_transfer_put_request["product_group_id"] = str(new_product_group)
 
         OCPTransferPutManager(
             self._fyre_user_name,

--- a/dg/lib/fyre/types/ocp_transfer_put_request.py
+++ b/dg/lib/fyre/types/ocp_transfer_put_request.py
@@ -19,6 +19,7 @@ OCPTransferPutRequest = TypedDict(
     {
         "comment": str,
         "new_owner": str,
+        "product_group_id": str,
     },
     total=False,
 )


### PR DESCRIPTION
This pull request contains the following changes:

- Add support for transferring ownership of a FYRE cluster to another product group (see [Slack announcement](https://ibm-analytics.slack.com/archives/C0ZF8PWBY/p1625779179092200))