### PR TITLE
Fix 'dg fyre info get-quota'

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -34,7 +34,7 @@
 	"python.testing.pytestEnabled": false,
 	"python.testing.unittestArgs": [
 		"--start-directory",
-		"test",
+		"tests.test",
 	],
 	"python.testing.unittestEnabled": true,
 	"search.exclude": {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -34,7 +34,7 @@
 	"python.testing.pytestEnabled": false,
 	"python.testing.unittestArgs": [
 		"--start-directory",
-		"tests.test",
+		"tests.test"
 	],
 	"python.testing.unittestEnabled": true,
 	"search.exclude": {

--- a/dg/lib/error.py
+++ b/dg/lib/error.py
@@ -31,6 +31,9 @@ class DataGateCLIException(Exception):
 
         return output
 
+    def get_error_message(self):
+        return self._error_message
+
 
 class IBMCloudException(DataGateCLIException):
     @classmethod

--- a/dg/lib/fyre/data/ocp_available_data.py
+++ b/dg/lib/fyre/data/ocp_available_data.py
@@ -35,7 +35,6 @@ class OCPAvailableData:
             click.echo(json.dumps(self._ocp_available_get_response, indent="\t", sort_keys=True))
         else:
             keys_union: List[str] = []
-            keys_union += self._ocp_available_get_response["default_size"]["bootstrap"].keys()
             keys_union += self._ocp_available_get_response["default_size"]["inf"].keys()
             keys_union += self._ocp_available_get_response["default_size"]["master"].keys()
             keys_union += self._ocp_available_get_response["default_size"]["worker"].keys()
@@ -46,12 +45,6 @@ class OCPAvailableData:
 
             for key in keys_union:
                 default_size_list: List[str] = [key]
-
-                default_size_list.append(
-                    self._ocp_available_get_response["default_size"]["bootstrap"][key]
-                    if key in self._ocp_available_get_response["default_size"]["bootstrap"]
-                    else "-"
-                )
 
                 default_size_list.append(
                     self._ocp_available_get_response["default_size"]["inf"][key]
@@ -73,7 +66,7 @@ class OCPAvailableData:
 
                 default_sizes_list.append(default_size_list)
 
-            click.echo(tabulate(default_sizes_list, headers=["default size", "inf", "bootstrap", "master", "worker"]))
+            click.echo(tabulate(default_sizes_list, headers=["default size", "inf", "master", "worker"]))
 
     def format_openshift_versions(self, use_json: bool = False):
         if use_json:

--- a/dg/lib/fyre/data/product_group_quota_data.py
+++ b/dg/lib/fyre/data/product_group_quota_data.py
@@ -52,44 +52,55 @@ class ProductGroupQuotaData:
             bold=True,
         )
 
-        product_group_quota_p = product_group_quota["p"]
-        product_group_quota_x = product_group_quota["x"]
-        product_group_quota_z = product_group_quota["z"]
-
-        quota_list_element_p: List[str] = [
-            "p",
-            product_group_quota_p["cpu"] if "cpu" in product_group_quota_p else "-",
-            str(product_group_quota_p["cpu_percent"]) if "cpu" in product_group_quota_p else "-",
-            product_group_quota_p["disk"] if "disk" in product_group_quota_p else "-",
-            str(product_group_quota_p["disk_percent"]) if "disk" in product_group_quota_p else "-",
-            product_group_quota_p["memory"] if "memory" in product_group_quota_p else "-",
-            str(product_group_quota_p["memory_percent"]) if "memory" in product_group_quota_p else "-",
-        ]
-
-        quota_list_element_x: List[str] = [
-            "x",
-            product_group_quota_x["cpu"] if "cpu" in product_group_quota_x else "-",
-            str(product_group_quota_x["cpu_percent"]) if "cpu" in product_group_quota_x else "-",
-            product_group_quota_x["disk"] if "disk" in product_group_quota_x else "-",
-            str(product_group_quota_x["disk_percent"]) if "disk" in product_group_quota_x else "-",
-            product_group_quota_x["memory"] if "memory" in product_group_quota_x else "-",
-            str(product_group_quota_x["memory_percent"]) if "memory" in product_group_quota_x else "-",
-        ]
-
-        quota_list_element_z: List[str] = [
-            "z",
-            product_group_quota_z["cpu"] if "cpu" in product_group_quota_z else "-",
-            str(product_group_quota_z["cpu_percent"]) if "cpu" in product_group_quota_z else "-",
-            product_group_quota_z["disk"] if "disk" in product_group_quota_z else "-",
-            str(product_group_quota_z["disk_percent"]) if "disk" in product_group_quota_z else "-",
-            product_group_quota_z["memory"] if "memory" in product_group_quota_z else "-",
-            str(product_group_quota_z["memory_percent"]) if "memory" in product_group_quota_z else "-",
-        ]
-
         quota_list: List[List[str]] = []
-        quota_list.append(quota_list_element_p)
-        quota_list.append(quota_list_element_x)
-        quota_list.append(quota_list_element_z)
+
+        if "p" in product_group_quota:
+            product_group_quota_p = product_group_quota["p"]
+            quota_list_element_p: List[str] = [
+                "p",
+                product_group_quota_p["cpu"] if "cpu" in product_group_quota_p else "-",
+                str(product_group_quota_p["cpu_percent"]) if "cpu" in product_group_quota_p else "-",
+                product_group_quota_p["disk"] if "disk" in product_group_quota_p else "-",
+                str(product_group_quota_p["disk_percent"]) if "disk" in product_group_quota_p else "-",
+                product_group_quota_p["memory"] if "memory" in product_group_quota_p else "-",
+                str(product_group_quota_p["memory_percent"]) if "memory" in product_group_quota_p else "-",
+            ]
+
+            quota_list.append(quota_list_element_p)
+        else:
+            quota_list.append(["p", "-", "-", "-", "-", "-", "-"])
+
+        if "x" in product_group_quota:
+            product_group_quota_x = product_group_quota["x"]
+            quota_list_element_x: List[str] = [
+                "x",
+                product_group_quota_x["cpu"] if "cpu" in product_group_quota_x else "-",
+                str(product_group_quota_x["cpu_percent"]) if "cpu" in product_group_quota_x else "-",
+                product_group_quota_x["disk"] if "disk" in product_group_quota_x else "-",
+                str(product_group_quota_x["disk_percent"]) if "disk" in product_group_quota_x else "-",
+                product_group_quota_x["memory"] if "memory" in product_group_quota_x else "-",
+                str(product_group_quota_x["memory_percent"]) if "memory" in product_group_quota_x else "-",
+            ]
+
+            quota_list.append(quota_list_element_x)
+        else:
+            quota_list.append(["x", "-", "-", "-", "-", "-", "-"])
+
+        if "z" in product_group_quota:
+            product_group_quota_z = product_group_quota["z"]
+            quota_list_element_z: List[str] = [
+                "z",
+                product_group_quota_z["cpu"] if "cpu" in product_group_quota_z else "-",
+                str(product_group_quota_z["cpu_percent"]) if "cpu" in product_group_quota_z else "-",
+                product_group_quota_z["disk"] if "disk" in product_group_quota_z else "-",
+                str(product_group_quota_z["disk_percent"]) if "disk" in product_group_quota_z else "-",
+                product_group_quota_z["memory"] if "memory" in product_group_quota_z else "-",
+                str(product_group_quota_z["memory_percent"]) if "memory" in product_group_quota_z else "-",
+            ]
+
+            quota_list.append(quota_list_element_z)
+        else:
+            quota_list.append(["z", "-", "-", "-", "-", "-", "-"])
 
         click.echo(
             tabulate(

--- a/dg/lib/fyre/data/product_group_quota_data.py
+++ b/dg/lib/fyre/data/product_group_quota_data.py
@@ -21,6 +21,7 @@ import click
 from tabulate import tabulate
 
 from dg.lib.fyre.types.quota_get_response import (
+    PlatformQuota,
     ProductGroupQuota,
     QuotaGetResponse,
 )
@@ -45,6 +46,19 @@ class ProductGroupQuotaData:
                     click.echo()
                     self._format_product_group_quota(product_group)
 
+    def _add_quota_list_element(self, quota_list: List[List[str]], platform: str, product_group_quota: PlatformQuota):
+        quota_list_element: List[str] = [
+            platform,
+            product_group_quota["cpu"] if "cpu" in product_group_quota else "-",
+            str(product_group_quota["cpu_percent"]) if "cpu" in product_group_quota else "-",
+            product_group_quota["disk"] if "disk" in product_group_quota else "-",
+            str(product_group_quota["disk_percent"]) if "disk" in product_group_quota else "-",
+            product_group_quota["memory"] if "memory" in product_group_quota else "-",
+            str(product_group_quota["memory_percent"]) if "memory" in product_group_quota else "-",
+        ]
+
+        quota_list.append(quota_list_element)
+
     def _format_product_group_quota(self, product_group_quota: ProductGroupQuota):
         click.secho(
             f"Product group: {product_group_quota['product_group_name']} (ID: "
@@ -55,50 +69,17 @@ class ProductGroupQuotaData:
         quota_list: List[List[str]] = []
 
         if "p" in product_group_quota:
-            product_group_quota_p = product_group_quota["p"]
-            quota_list_element_p: List[str] = [
-                "p",
-                product_group_quota_p["cpu"] if "cpu" in product_group_quota_p else "-",
-                str(product_group_quota_p["cpu_percent"]) if "cpu" in product_group_quota_p else "-",
-                product_group_quota_p["disk"] if "disk" in product_group_quota_p else "-",
-                str(product_group_quota_p["disk_percent"]) if "disk" in product_group_quota_p else "-",
-                product_group_quota_p["memory"] if "memory" in product_group_quota_p else "-",
-                str(product_group_quota_p["memory_percent"]) if "memory" in product_group_quota_p else "-",
-            ]
-
-            quota_list.append(quota_list_element_p)
+            self._add_quota_list_element(quota_list, "p", product_group_quota["p"])
         else:
             quota_list.append(["p", "-", "-", "-", "-", "-", "-"])
 
         if "x" in product_group_quota:
-            product_group_quota_x = product_group_quota["x"]
-            quota_list_element_x: List[str] = [
-                "x",
-                product_group_quota_x["cpu"] if "cpu" in product_group_quota_x else "-",
-                str(product_group_quota_x["cpu_percent"]) if "cpu" in product_group_quota_x else "-",
-                product_group_quota_x["disk"] if "disk" in product_group_quota_x else "-",
-                str(product_group_quota_x["disk_percent"]) if "disk" in product_group_quota_x else "-",
-                product_group_quota_x["memory"] if "memory" in product_group_quota_x else "-",
-                str(product_group_quota_x["memory_percent"]) if "memory" in product_group_quota_x else "-",
-            ]
-
-            quota_list.append(quota_list_element_x)
+            self._add_quota_list_element(quota_list, "x", product_group_quota["x"])
         else:
             quota_list.append(["x", "-", "-", "-", "-", "-", "-"])
 
         if "z" in product_group_quota:
-            product_group_quota_z = product_group_quota["z"]
-            quota_list_element_z: List[str] = [
-                "z",
-                product_group_quota_z["cpu"] if "cpu" in product_group_quota_z else "-",
-                str(product_group_quota_z["cpu_percent"]) if "cpu" in product_group_quota_z else "-",
-                product_group_quota_z["disk"] if "disk" in product_group_quota_z else "-",
-                str(product_group_quota_z["disk_percent"]) if "disk" in product_group_quota_z else "-",
-                product_group_quota_z["memory"] if "memory" in product_group_quota_z else "-",
-                str(product_group_quota_z["memory_percent"]) if "memory" in product_group_quota_z else "-",
-            ]
-
-            quota_list.append(quota_list_element_z)
+            self._add_quota_list_element(quota_list, "z", product_group_quota["z"])
         else:
             quota_list.append(["z", "-", "-", "-", "-", "-", "-"])
 

--- a/dg/lib/fyre/response_managers/ocp_available_get_response_manager.py
+++ b/dg/lib/fyre/response_managers/ocp_available_get_response_manager.py
@@ -43,13 +43,11 @@ class OCPAvailableGetResponseManager(AbstractJSONResponseManager):
                 "defaultClusterSizeData": {
                     "additionalProperties": False,
                     "properties": {
-                        "bootstrap": {"$ref": node_size_ref},
                         "inf": {"$ref": node_size_ref},
                         "master": {"$ref": node_size_ref},
                         "worker": {"$ref": node_size_ref},
                     },
                     "required": [
-                        "bootstrap",
                         "inf",
                         "master",
                         "worker",

--- a/dg/lib/fyre/response_managers/ocp_quick_burn_sizes_response_manager.py
+++ b/dg/lib/fyre/response_managers/ocp_quick_burn_sizes_response_manager.py
@@ -42,10 +42,19 @@ class OCPQuickBurnSizesResponseManager(AbstractJSONResponseManager):
                 "nodeSizeSpecification": {
                     "additionalProperties": False,
                     "properties": {
+                        "additional_disk": {
+                            "type": "string",
+                        },
+                        "additional_disk_size": {
+                            "type": "string",
+                        },
                         "count": {
                             "type": "string",
                         },
                         "cpu": {
+                            "type": "string",
+                        },
+                        "disk_size": {
                             "type": "string",
                         },
                         "memory": {
@@ -53,8 +62,10 @@ class OCPQuickBurnSizesResponseManager(AbstractJSONResponseManager):
                         },
                     },
                     "required": [
+                        "additional_disk",
                         "count",
                         "cpu",
+                        "disk_size",
                         "memory",
                     ],
                 },

--- a/dg/lib/fyre/response_managers/quota_get_response_manager.py
+++ b/dg/lib/fyre/response_managers/quota_get_response_manager.py
@@ -73,11 +73,8 @@ class QuotaGetResponseManager(AbstractJSONResponseManager):
                         },
                     },
                     "required": [
-                        "p",
                         "product_group_id",
                         "product_group_name",
-                        "x",
-                        "z",
                     ],
                     "type": "object",
                 },

--- a/dg/lib/fyre/types/ocp_add_additional_nodes_put_request.py
+++ b/dg/lib/fyre/types/ocp_add_additional_nodes_put_request.py
@@ -14,14 +14,10 @@
 
 from typing import List, TypedDict
 
-OCPAddAdditionalNodesPutRequest = TypedDict(
-    "OCPAddAdditionalNodesPutRequest",
-    {
-        "additional_disk": List[str],
-        "cpu": str,
-        "disable_scheduling": str,
-        "memory": str,
-        "vm_count": str,
-    },
-    total=False,
-)
+
+class OCPAddAdditionalNodesPutRequest(TypedDict, total=False):
+    additional_disk: List[str]
+    cpu: str
+    disable_scheduling: str
+    memory: str
+    vm_count: str

--- a/dg/lib/fyre/types/ocp_available_get_response.py
+++ b/dg/lib/fyre/types/ocp_available_get_response.py
@@ -29,7 +29,6 @@ class NodeSize(TypedDict):
 
 
 class DefaultClusterSizeData(TypedDict):
-    bootstrap: NodeSize
     inf: NodeSize
     master: NodeSize
     worker: NodeSize

--- a/dg/lib/fyre/types/ocp_post_request.py
+++ b/dg/lib/fyre/types/ocp_post_request.py
@@ -30,35 +30,27 @@ HAProxyTimeoutData = TypedDict(
 
 HAProxyData = TypedDict("HAProxyData", {"timeout": HAProxyTimeoutData})
 
-WorkerData = TypedDict(
-    "WorkerData",
-    {
-        "additional_disk": List[str],
-        "count": str,
-        "cpu": str,
-        "memory": str,
-    },
-    total=False,
-)
 
-OCPPostRequest = TypedDict(
-    "ClusterSpecification",
-    {
-        "description": str,
-        "expiration": str,
-        "fips": str,
-        "haproxy": HAProxyData,
-        "name": str,
-        "ocp_version": str,
-        "platform": str,
-        "product_group_id": str,
-        "pull_secret": str,
-        "quota_type": str,
-        "site": str,
-        "size": str,
-        "ssh_key": str,
-        "time_to_live": str,
-        "worker": List[WorkerData],
-    },
-    total=False,
-)
+class WorkerData(TypedDict, total=False):
+    additional_disk: List[str]
+    count: str
+    cpu: str
+    memory: str
+
+
+class OCPPostRequest(TypedDict, total=False):
+    description: str
+    expiration: str
+    fips: str
+    haproxy: HAProxyData
+    name: str
+    ocp_version: str
+    platform: str
+    product_group_id: str
+    pull_secret: str
+    quota_type: str
+    site: str
+    size: str
+    ssh_key: str
+    time_to_live: str
+    worker: List[WorkerData]

--- a/dg/lib/fyre/types/ocp_quick_burn_sizes_response.py
+++ b/dg/lib/fyre/types/ocp_quick_burn_sizes_response.py
@@ -16,8 +16,11 @@ from typing import TypedDict
 
 
 class NodeSizeSpecification(TypedDict):
+    additional_disk: str
+    additional_disk_size: str
     count: str
     cpu: str
+    disk_size: str
     memory: str
 
 

--- a/dg/lib/fyre/types/ocp_resource_put_request.py
+++ b/dg/lib/fyre/types/ocp_resource_put_request.py
@@ -14,11 +14,7 @@
 
 from typing import TypedDict
 
-OCPResourcePutRequest = TypedDict(
-    "OCPResourcePutRequest",
-    {
-        "cpu": str,
-        "memory": str,
-    },
-    total=False,
-)
+
+class OCPResourcePutRequest(TypedDict, total=False):
+    cpu: str
+    memory: str

--- a/dg/lib/fyre/types/ocp_transfer_put_request.py
+++ b/dg/lib/fyre/types/ocp_transfer_put_request.py
@@ -14,12 +14,8 @@
 
 from typing import TypedDict
 
-OCPTransferPutRequest = TypedDict(
-    "OCPTransferPutRequest",
-    {
-        "comment": str,
-        "new_owner": str,
-        "product_group_id": str,
-    },
-    total=False,
-)
+
+class OCPTransferPutRequest(TypedDict, total=False):
+    comment: str
+    new_owner: str
+    product_group_id: str

--- a/dg/lib/fyre/types/quota_get_response.py
+++ b/dg/lib/fyre/types/quota_get_response.py
@@ -28,11 +28,11 @@ class PlatformQuota(TypedDict):
 
 
 class ProductGroupQuota(TypedDict):
-    p: PlatformQuota
+    p: PlatformQuota  # optional
     product_group_id: str
     product_group_name: str
-    x: PlatformQuota
-    z: PlatformQuota
+    x: PlatformQuota  # optional
+    z: PlatformQuota  # optional
 
 
 class QuotaGetResponse(TypedDict):

--- a/tests/test_fyre/test_fyre_commands.py
+++ b/tests/test_fyre/test_fyre_commands.py
@@ -31,6 +31,7 @@ import dg.utils.logging
 
 from dg.config import data_gate_configuration_manager
 from dg.dg import cli
+from dg.lib.error import DataGateCLIException
 
 dg.utils.logging.init_root_logger()
 
@@ -117,18 +118,24 @@ class TestFYRECommands(unittest.TestCase):
         self._node_action("worker3", NodeAction.BOOT_NODE)
         self._node_action("worker3", NodeAction.REBOOT_NODE)
 
-        try:
-            self._node_action("worker3", NodeAction.REDEPLOY_NODE)
-        except Exception as exception:
+        result = self._node_action("worker3", NodeAction.REDEPLOY_NODE, ignore_exception=True)
+
+        if (
+            result.exit_code != 0
+            and result.exception is not None
+            and isinstance(result.exception, DataGateCLIException)
+        ):
+            exception: DataGateCLIException = result.exception
+
             if (
-                regex.search(
-                    "Error: Failed to redeploy node \\[HTTP status code: 400\\] \\('No space available on any [p|x|z] "
-                    "host to redeploy vm for user id \\d+'\\)",
-                    str(exception),
+                regex.match(
+                    "Failed to redeploy node \\[HTTP status code: 400\\] \\('No space available on any [p|x|z] host to "
+                    "redeploy vm for user id \\d+'\\)",
+                    exception.get_error_message(),
                 )
                 is None
             ):
-                raise exception
+                self._check_result(result)
 
         self._edit_inf_node()
         self._edit_master_node("master0")
@@ -290,20 +297,21 @@ class TestFYRECommands(unittest.TestCase):
 
         self._invoke_dg_command(args)
 
-    def _invoke_dg_command(self, args: List[str], expected_exit_code=0) -> click.testing.Result:
+    def _invoke_dg_command(self, args: List[str], ignore_exception=False) -> click.testing.Result:
         TestFYRECommands._logger.info(f"Testing: dg {' '.join(args)}")
 
         runner = click.testing.CliRunner()
         result = runner.invoke(cli, args)
 
-        TestFYRECommands._check_result(result)
+        if not ignore_exception:
+            TestFYRECommands._check_result(result)
 
         return result
 
-    def _node_action(self, node_name: str, cluster_action: NodeAction):
+    def _node_action(self, node_name: str, cluster_action: NodeAction, ignore_exception=False) -> click.testing.Result:
         assert TestFYRECommands._cluster_name is not None
 
-        self._invoke_dg_command(
+        return self._invoke_dg_command(
             [
                 "fyre",
                 "cluster",
@@ -313,7 +321,8 @@ class TestFYRECommands(unittest.TestCase):
                 "--force",
                 "--node-name",
                 node_name,
-            ]
+            ],
+            ignore_exception=ignore_exception,
         )
 
     @classmethod

--- a/tests/test_fyre/test_fyre_commands.py
+++ b/tests/test_fyre/test_fyre_commands.py
@@ -116,7 +116,20 @@ class TestFYRECommands(unittest.TestCase):
         self._node_action("worker3", NodeAction.SHUTDOWN_NODE)
         self._node_action("worker3", NodeAction.BOOT_NODE)
         self._node_action("worker3", NodeAction.REBOOT_NODE)
-        self._node_action("worker3", NodeAction.REDEPLOY_NODE)
+
+        try:
+            self._node_action("worker3", NodeAction.REDEPLOY_NODE)
+        except Exception as exception:
+            if (
+                regex.search(
+                    "Error: Failed to redeploy node \\[HTTP status code: 400\\] \\('No space available on any [p|x|z] "
+                    "host to redeploy vm for user id \\d+'\\)",
+                    str(exception),
+                )
+                is None
+            ):
+                raise exception
+
         self._edit_inf_node()
         self._edit_master_node("master0")
         self._edit_worker_node("worker3")


### PR DESCRIPTION
This pull request contains the following changes:

- Fix `dg fyre info get-default-sizes` due to a change in one of the FYRE OCP+ APIs
- Fix `dg fyre info get-quick-burn-sizes` due to a change in one of the FYRE OCP+ APIs
- Fix `dg fyre info get-quota` due to a change in one of the FYRE OCP+ APIs