### PR TITLE
Ignore service unavailable errors when requesting IBM Cloud cluster status

### DIFF
--- a/dg/lib/error.py
+++ b/dg/lib/error.py
@@ -29,14 +29,35 @@ class DataGateCLIException(Exception):
     def get_error_message(self):
         return self._error_message
 
+    @property
+    def stderr(self) -> Optional[str]:
+        return self._stderr
+
+    @property
+    def stdout(self) -> Optional[str]:
+        return self._stdout
+
 
 class IBMCloudException(DataGateCLIException):
     @classmethod
     def get_parsed_error_message(cls, error_message: str) -> str:
+        # use regex.DOTALL to match newline characters
         search_result = regex.search("FAILED\\n(.*)\\n\\n(Incident ID: .*)\\n", error_message, regex.DOTALL)
 
         if search_result is not None:
             output = f"{search_result.group(1)} [{search_result.group(2)}]"
+        else:
+            output = error_message
+
+        return output
+
+    @classmethod
+    def get_parsed_error_message_without_incident_id(cls, error_message: str) -> str:
+        # use regex.DOTALL to match newline characters
+        search_result = regex.search("FAILED\\n(.*)\\n\\n(Incident ID: .*)\\n", error_message, regex.DOTALL)
+
+        if search_result is not None:
+            output = search_result.group(1)
         else:
             output = error_message
 

--- a/dg/lib/ibmcloud/__init__.py
+++ b/dg/lib/ibmcloud/__init__.py
@@ -1,10 +1,11 @@
 import subprocess
 
-from typing import Final, List
+from typing import Final, List, Optional
 
 import dg.utils.process
 
 from dg.config import data_gate_configuration_manager
+from dg.lib.error import DataGateCLIException, IBMCloudException
 
 EXTERNAL_IBM_CLOUD_API_KEY_NAME: Final[str] = "dg.api.key"
 INTERNAL_IBM_CLOUD_API_KEY_NAME: Final[str] = "ibm_cloud_api_key"
@@ -35,14 +36,20 @@ def execute_ibmcloud_command(
     """
 
     ibmcloud_cli_path = data_gate_configuration_manager.get_ibmcloud_cli_path()
+    process_result: Optional[dg.utils.process.ProcessResult] = None
 
-    return dg.utils.process.execute_command(
-        ibmcloud_cli_path,
-        args,
-        capture_output=capture_output,
-        check=check,
-        print_captured_output=print_captured_output,
-    )
+    try:
+        process_result = dg.utils.process.execute_command(
+            ibmcloud_cli_path,
+            args,
+            capture_output=capture_output,
+            check=check,
+            print_captured_output=print_captured_output,
+        )
+    except DataGateCLIException as exception:
+        raise IBMCloudException(exception.stderr)
+
+    return process_result
 
 
 def execute_ibmcloud_command_interactively(args: List[str]) -> int:

--- a/dg/utils/process.py
+++ b/dg/utils/process.py
@@ -88,7 +88,11 @@ def execute_command(
         if len(stderr_buffer) != 0:
             error_output = f" ({stderr_buffer})"
 
-        raise DataGateCLIException(f"Command '{command_string}' failed with return code {return_code}{error_output}.")
+        raise DataGateCLIException(
+            f"Command '{command_string}' failed with return code {return_code}{error_output}.",
+            "\n".join(stderr_buffer),
+            "\n".join(stdout_buffer),
+        )
 
     return ProcessResult(return_code, "\n".join(stderr_buffer), "\n".join(stdout_buffer))
 


### PR DESCRIPTION
This pull request contains the following changes:

- Store error output and standard output in `DataGateCLIException` class
- Raise `IBMCloudException` instead of `DataGateCLIException` when encountering an error in `execute_ibmcloud_command()`
- Ignore service unavailable errors (HTTP status code 503) when requesting IBM Cloud cluster status (these errors recently started to occur sporadically)