### PR TITLE
Use OpenShift 4.7 during Db2 Data Gate cluster creation

### DIFF
--- a/dg/commands/fyre/cluster/create_for_db2_data_gate.py
+++ b/dg/commands/fyre/cluster/create_for_db2_data_gate.py
@@ -83,7 +83,7 @@ def validate_worker_node_additional_disk_size(ctx, param, value: Optional[List[i
 )
 @optgroup.option("--haproxy-timeout-queue", callback=validate_haproxy_timeout_setting, help="HAProxy queue timeout")
 @optgroup.option("--haproxy-timeout-server", callback=validate_haproxy_timeout_setting, help="HAProxy server timeout")
-@optgroup.option("--ocp-version", callback=validate_ocp_version, help="OpenShift version")
+@optgroup.option("--ocp-version", callback=validate_ocp_version, default="4.7", help="OpenShift version")
 @optgroup.option("--platform", help="Platform", type=click.Choice(["p", "x", "z"]))
 @optgroup.option("--product-group-id", help="FYRE product group ID", type=click.INT)
 @optgroup.option("--pull-secret", help="Pull secret")


### PR DESCRIPTION
This pull request contains the following changes:

- Use OpenShift 4.7 during Db2 Data Gate cluster creation as OpenShift 4.8 (default version) is not supported by Cloud Pak for Data 4.0.0