### PR TITLE
Add option '--storage-vendor' to command 'dg cpd4 install'

### DIFF
--- a/dg/commands/cpd4/service/install.py
+++ b/dg/commands/cpd4/service/install.py
@@ -113,7 +113,7 @@ def install(
     )
 
     if (storage_class is not None) and (storage_vendor is not None):
-        raise click.UsageError("You must not set options '--storage-class' and '--storage_vendor'.", ctx)
+        raise click.UsageError("You must not set options '--storage-class' and '--storage-vendor'.", ctx)
 
     storage_option: Optional[Union[str, CloudPakForDataStorageVendor]] = (
         storage_class if storage_class is not None else cloud_pak_for_data_storage_vendor

--- a/dg/commands/cpd4/service/install_db2_data_gate_stack.py
+++ b/dg/commands/cpd4/service/install_db2_data_gate_stack.py
@@ -106,7 +106,7 @@ def install_db2_data_gate_stack(
     )
 
     if (storage_class is not None) and (storage_vendor is not None):
-        raise click.UsageError("You must not set options '--storage-class' and '--storage_vendor'.", ctx)
+        raise click.UsageError("You must not set options '--storage-class' and '--storage-vendor'.", ctx)
 
     storage_option: Optional[Union[str, CloudPakForDataStorageVendor]] = (
         storage_class if storage_class is not None else cloud_pak_for_data_storage_vendor
@@ -114,7 +114,7 @@ def install_db2_data_gate_stack(
 
     if storage_option is None:
         raise click.UsageError(
-            "You must set option '--storage-class' or '--storage_vendor' for the 'datagate' service."
+            "You must set option '--storage-class' or '--storage-vendor' for the 'datagate' service."
         )
 
     if not cloud_pak_for_data_manager.cloud_pak_for_data_service_installed(project, "db2oltp"):

--- a/dg/lib/cloud_pak_for_data/cpd_4_0_0/types/custom_resource_metadata.py
+++ b/dg/lib/cloud_pak_for_data/cpd_4_0_0/types/custom_resource_metadata.py
@@ -72,7 +72,7 @@ class CustomResourceMetadata:
             )
 
         if storage_option is None and self._storage_option_required:
-            raise DataGateCLIException("You must set option '--storage-class' or '--storage_vendor' for this service.")
+            raise DataGateCLIException("You must set option '--storage-class' or '--storage-vendor' for this service.")
 
     @property
     def description(self) -> str:

--- a/dg/lib/openshift/openshift_api_manager.py
+++ b/dg/lib/openshift/openshift_api_manager.py
@@ -924,9 +924,9 @@ class OpenShiftAPIManager:
             "apiVersion": "storage.k8s.io/v1",
             "kind": "StorageClass",
             "metadata": {
-                "name": "managed-nfs-storage",
+                "name": name,
             },
-            "provisioner": "k8s-sigs.io/nfs-subdir-external-provisioner",
+            "provisioner": provisioner,
         }
 
         storage_class["parameters"] = parameters

--- a/docs/installing_ibm_cloud_pak_for_data_on_a_fyre-based_openshift_cluster.md
+++ b/docs/installing_ibm_cloud_pak_for_data_on_a_fyre-based_openshift_cluster.md
@@ -89,11 +89,11 @@
   - Install IBM Cloud Pak for Data:
 
     ```shell
-    dg cpd4 install --accept-license --force --license (ENTERPRISE|STANDARD) --storage-class managed-nfs-storage
+    dg cpd4 install --accept-license --force --license (ENTERPRISE|STANDARD) --storage-vendor nfs
     ```
 
   - Install IBM Db2, IBM Db2 Warehouse, IBM Db2 Data Management Console, and IBM Db2 for z/OS Data Gate:
 
     ```shell
-    dg cpd4 service install-db2-data-gate-stack --accept-all-licenses --db2-license (ADVANCED|COMMUNITY|STANDARD) --license (ENTERPRISE|STANDARD) --storage-class managed-nfs-storage
+    dg cpd4 service install-db2-data-gate-stack --accept-all-licenses --db2-license (ADVANCED|COMMUNITY|STANDARD) --license (ENTERPRISE|STANDARD) --storage-vendor nfs
     ```

--- a/tests/test_fyre/test_fyre_commands.py
+++ b/tests/test_fyre/test_fyre_commands.py
@@ -303,7 +303,7 @@ class TestFYRECommands(unittest.TestCase):
                 TestFYRECommands._logger.info(f"Ignoring exception: {exception.get_error_message()}")
 
     def _install_db2_data_gate_stack(self):
-        args = ["cluster", "install-db2-data-gate-stack", "--storage-class", "managed-nfs-storage"]
+        args = ["cluster", "install-db2-data-gate-stack", "--storage-vendor", "nfs"]
 
         self._invoke_dg_command(args)
 


### PR DESCRIPTION
This pull request contains the following changes:

- Add option '--storage-vendor' to command 'dg cpd4 install' (see [docs](https://www.ibm.com/docs/en/cloud-paks/cp-data/4.0?topic=installing-cloud-pak-data))