### PR TITLE
Fix logging issues

### DIFF
--- a/dg/deps/config/cpd-custom-resources.json
+++ b/dg/deps/config/cpd-custom-resources.json
@@ -1,7 +1,7 @@
 {
 	"datagate": {
-		"api_version": "datagate.cpd.ibm.com/v1",
 		"description": "Db2 Data Gate",
+		"group": "datagate.cpd.ibm.com",
 		"kind": "DatagateService",
 		"licenses": [
 			"Enterprise",
@@ -14,11 +14,12 @@
 			"version": "2.0.2"
 		},
 		"status_key_name": "datagateStatus",
-		"storage_option_required": true
+		"storage_option_required": true,
+		"version": "v1"
 	},
 	"db2oltp": {
-		"api_version": "databases.cpd.ibm.com/v1",
 		"description": "Db2",
+		"group": "databases.cpd.ibm.com",
 		"kind": "Db2oltpService",
 		"licenses": [
 			"Advanced",
@@ -29,11 +30,12 @@
 		"operator_name": "ibm-db2oltp-cp4d-operator",
 		"spec": {},
 		"status_key_name": "db2oltpStatus",
-		"storage_option_required": false
+		"storage_option_required": false,
+		"version": "v1"
 	},
 	"db2wh": {
-		"api_version": "databases.cpd.ibm.com/v1",
 		"description": "Db2 Warehouse",
+		"group": "databases.cpd.ibm.com",
 		"kind": "Db2whService",
 		"licenses": [
 			"Enterprise",
@@ -43,11 +45,12 @@
 		"operator_name": "ibm-db2wh-cp4d-operator",
 		"spec": {},
 		"status_key_name": "db2whStatus",
-		"storage_option_required": false
+		"storage_option_required": false,
+		"version": "v1"
 	},
 	"dmc": {
-		"api_version": "dmc.databases.ibm.com/v1",
 		"description": "Db2 Data Management Console",
+		"group": "dmc.databases.ibm.com",
 		"kind": "Dmcaddon",
 		"licenses": [
 			"Enterprise",
@@ -59,6 +62,7 @@
 			"version": "4.0.2"
 		},
 		"status_key_name": "dmcAddonStatus",
-		"storage_option_required": false
+		"storage_option_required": false,
+		"version": "v1"
 	}
 }

--- a/dg/lib/cloud_pak_for_data/cpd_4_0_0/cpd_service_manager.py
+++ b/dg/lib/cloud_pak_for_data/cpd_4_0_0/cpd_service_manager.py
@@ -135,8 +135,8 @@ class CloudPakForDataServiceManager:
             ) as json_file:
                 for key, value in json.load(json_file).items():
                     self._custom_resources[key] = CustomResourceMetadata(
-                        api_version=value["api_version"],
                         description=value["description"],
+                        group=value["group"],
                         kind=value["kind"],
                         licenses=list(map(lambda license: CloudPakForDataServiceLicense[license], value["licenses"])),
                         name=value["name"],
@@ -144,6 +144,7 @@ class CloudPakForDataServiceManager:
                         spec=value["spec"],
                         status_key_name=value["status_key_name"],
                         storage_option_required=value["storage_option_required"],
+                        version=value["version"],
                     )
 
     def _initialize_subscriptions_dict_if_required(self):

--- a/dg/lib/cloud_pak_for_data/cpd_4_0_0/types/custom_resource_definitions_event_data.py
+++ b/dg/lib/cloud_pak_for_data/cpd_4_0_0/types/custom_resource_definitions_event_data.py
@@ -1,0 +1,25 @@
+#  Copyright 2021 IBM Corporation
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from dataclasses import dataclass, field
+from typing import Set
+
+from halo.halo import Halo
+
+
+@dataclass
+class CustomResourceDefinitionsEventData:
+    expected_crd_kinds: Set[str]
+    spinner: Halo
+    encountered_crd_kinds: Set[str] = field(default_factory=set)

--- a/dg/lib/cloud_pak_for_data/cpd_4_0_0/types/custom_resource_event_data.py
+++ b/dg/lib/cloud_pak_for_data/cpd_4_0_0/types/custom_resource_event_data.py
@@ -14,8 +14,12 @@
 
 from dataclasses import dataclass
 
+from halo.halo import Halo
+
 
 @dataclass
-class APIVersion:
-    group: str
-    version: str
+class CustomResourceEventData:
+    name: str
+    spinner: Halo
+    status_key: str
+    initial_event = True

--- a/dg/lib/openshift/types/custom_resource.py
+++ b/dg/lib/openshift/types/custom_resource.py
@@ -12,13 +12,31 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+from dataclasses import dataclass
 from typing import Any, Dict, TypedDict
 
 from dg.lib.openshift.types.object_meta import ObjectMeta
 
 
-class CustomResource(TypedDict):
+class CustomResourceDict(TypedDict):
     apiVersion: str
     kind: str
     metadata: ObjectMeta
     spec: Dict[str, Any]
+
+
+@dataclass
+class CustomResource:
+    group: str
+    kind: str
+    metadata: ObjectMeta
+    spec: Dict[str, Any]
+    version: str
+
+    def create_custom_resource_dict(self) -> CustomResourceDict:
+        return {
+            "apiVersion": f"{self.group}/{self.version}",
+            "kind": self.kind,
+            "metadata": self.metadata,
+            "spec": self.spec,
+        }


### PR DESCRIPTION
This pull request contains the following changes:

### General

- Remove log output from methods that may be re-executed if the OAuth access token expired to prevent redundant log messages

### dg/deps/config/cpd-custom-resources.json

- Split `api_version` key into `group` and `version` keys

### dg/lib/cloud_pak_for_data/cpd_4_0_0/cpd_manager.py

- Move methods to `dg/lib/openshift/openshift_api_manager.py`:
  - `_get_custom_resources`
  - `_handle_api_exception`
  - `_handle_protocol_error`
  - `_wait_for_custom_resource`
  - `_wait_for_namespaced_custom_resource`

- Delete methods:
  - `_delete_cluster_service_version`
  - `_delete_subscription`

- Rename methods:
  - `custom_resource_status_completed` → `_custom_resource_status_is_completed`
  - `_custom_resource_definitions_are_created` → `_add_event_indicates_custom_resource_definitions_are_created`
  - `_custom_resource_is_deleted` → `_delete_event_indicates_custom_resource_is_deleted`
  - `_custom_resource_status_is_completed` → `_add_event_indicates_custom_resource_status_is_completed`

- Split `_create_operator_group()` into two methods (`_create_operator_group` and `_create_operator_subscription_dependencies`) to reduce visual complexity

- Resume `dg cpd4 install` if the command is re-executed even after the `Ibmcpd` custom resource was created
- Improve logging in `_add_event_indicates_custom_resource_status_is_completed()`

### dg/lib/openshift/openshift_api_manager.py

- Add methods:
  - `create_custom_resource`
  - `delete_custom_resource`
 
- Rename methods:
  - `get_custom_resource_if_exists` → `get_namespaced_custom_resource_if_exists`
  - `_get_custom_resource_if_exists` → `_get_namespaced_custom_resource_if_exists`