### PR TITLE
Remove setup_requires from setup.cfg

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [build-system]
 build-backend = "setuptools.build_meta"
 requires = [
+	"setuptools-git-versioning",
 	"setuptools>=42",
 	"wheel"
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,9 +20,6 @@ long_description = file: README.md
 long_description_content_type = text/markdown
 
 [options]
-setup_requires =
-    setuptools-git-versioning
-
 install_requires =
     asyncssh
     click


### PR DESCRIPTION
This pull request contains the following changes:

- Migrate deprecated `setup_requires` in setup.cfg to PEP 518 `build-system.requires` in pyproject.toml (see [changelog](https://setuptools.pypa.io/en/latest/history.html#v58-3-0) of setuptools package for background information)

